### PR TITLE
fix: change input focus outline to red for error states

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -170,9 +170,9 @@ select:focus-visible {
 
 /* Error state focus ring color */
 /* Auto-detect error state by border-red-* class */
-input[class*="border-red"]:focus-visible,
-textarea[class*="border-red"]:focus-visible,
-select[class*="border-red"]:focus-visible {
+input[class*='border-red']:focus-visible,
+textarea[class*='border-red']:focus-visible,
+select[class*='border-red']:focus-visible {
   outline: 2px solid var(--error);
   outline-offset: 2px;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -168,6 +168,23 @@ select:focus-visible {
   outline-offset: 2px;
 }
 
+/* Error state focus ring color */
+/* Auto-detect error state by border-red-* class */
+input[class*="border-red"]:focus-visible,
+textarea[class*="border-red"]:focus-visible,
+select[class*="border-red"]:focus-visible {
+  outline: 2px solid var(--error);
+  outline-offset: 2px;
+}
+
+/* Explicit error state with .input-error class */
+input.input-error:focus-visible,
+textarea.input-error:focus-visible,
+select.input-error:focus-visible {
+  outline: 2px solid var(--error);
+  outline-offset: 2px;
+}
+
 /* Custom select chevron styling */
 select {
   appearance: none;

--- a/src/components/AddTaskDialog.tsx
+++ b/src/components/AddTaskDialog.tsx
@@ -251,7 +251,7 @@ export function AddTaskDialog({ isOpen, onClose, onAdd, repositories }: AddTaskD
               value={formData.branch}
               onChange={(e) => setFormData({ ...formData, branch: e.target.value })}
               className={`w-full px-3 py-2 border rounded text-theme-fg bg-theme-card ${
-                fieldErrors.branch ? 'border-red-500' : 'border-theme'
+                fieldErrors.branch ? 'border-red-500 input-error' : 'border-theme'
               }`}
               placeholder="feature/new-feature"
               disabled={isLoading}


### PR DESCRIPTION
Update focus-visible outline color from green (primary) to red (error) when input fields are in an error state, improving visual feedback consistency.

Changes:
- Add CSS rules to detect error states via border-red-* class
- Add explicit .input-error class for error state marking
- Apply input-error class to AddTaskDialog branch input field