### PR TITLE
fix: clear prompt editor after message appears in logs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1899,14 +1899,6 @@
         "@types/react": "^19.2.0"
       }
     },
-    "node_modules/@types/trusted-types": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/trusted-types": "^2.0.7",
         "@types/uuid": "^10.0.0",
         "eslint": "^9",
         "eslint-config-next": "16.0.10",
@@ -1898,6 +1899,13 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/trusted-types": "^2.0.7",
     "@types/uuid": "^10.0.0",
     "eslint": "^9",
     "eslint-config-next": "16.0.10",

--- a/src/app/tasks/[id]/page.tsx
+++ b/src/app/tasks/[id]/page.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import { use, useState, useEffect } from 'react';
+import { use, useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { ArrowLeft } from 'lucide-react';
-import type { Task, Tab } from '@/lib/types';
+import type { Task, Tab, MergedMessage } from '@/lib/types';
 import { TaskInfo } from '@/components/TaskInfo';
 import { SessionTabs } from '@/components/SessionTabs';
 import { ViewLayoutToggle, type ViewMode } from '@/components/ViewLayoutToggle';
-import { ClaudePromptEditor } from '@/components/ClaudePromptEditor';
+import { ClaudePromptEditor, type ClaudePromptEditorRef } from '@/components/ClaudePromptEditor';
 import { ExecutionLogsChat } from '@/components/ExecutionLogsChat';
 import { TaskActions } from '@/components/TaskActions';
 import { LoadingSpinner } from '@/components/LoadingSpinner';
@@ -25,11 +25,15 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
   const [task, setTask] = useState<Task | null>(null);
   const [tabs, setTabs] = useState<Tab[]>([]);
   const [activeTabId, setActiveTabId] = useState<string | undefined>();
-  const [tabMessages, setTabMessages] = useState<Record<string, unknown[]>>({});
+  const [tabMessages, setTabMessages] = useState<Record<string, MergedMessage[]>>({});
   const [viewMode, setViewMode] = useState<ViewMode>('split');
-  const [prompts, setPrompts] = useState<Record<string, string>>({});
+  const [initialPrompts, setInitialPrompts] = useState<Record<string, string>>({});
+  const [pendingPrompts, setPendingPrompts] = useState<Record<string, string>>({});
   const [isLoading, setIsLoading] = useState(true);
   const [isEditingTask, setIsEditingTask] = useState(false);
+
+  // エディタのrefを保持
+  const editorRef = useRef<ClaudePromptEditorRef>(null);
 
   const activeTab = tabs.find((t) => t.tab_id === activeTabId);
 
@@ -82,7 +86,7 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
         });
 
         const messagesResults = await Promise.all(messagesPromises);
-        const messagesMap: Record<string, unknown[]> = {};
+        const messagesMap: Record<string, MergedMessage[]> = {};
         messagesResults.forEach((result) => {
           messagesMap[result.tab_id] = result.messages;
         });
@@ -152,8 +156,58 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
     const handleTabMessagesUpdated = (event: MessageEvent) => {
       const { tab_id, messages } = JSON.parse(event.data) as {
         tab_id: string;
-        messages: unknown[];
+        messages: MergedMessage[];
       };
+
+      // pendingPromptがある場合のみチェック
+      const pendingPrompt = pendingPrompts[tab_id];
+
+      if (pendingPrompt && tab_id === activeTabId) {
+        const prevMessages = tabMessages[tab_id] || [];
+
+        // 新しいメッセージの中に、送信したプロンプトと一致するものがあるか確認
+        if (messages.length > prevMessages.length) {
+          const matchFound = messages.some((msg) => {
+            // type: 'prompt'メッセージのみチェック（userPromptsから生成されたメッセージ）
+            if (!('type' in msg) || msg.type !== 'prompt') {
+              return false;
+            }
+
+            // messageフィールドとcontentフィールドの存在確認
+            if (!('message' in msg) || typeof msg.message !== 'object' || msg.message === null) {
+              return false;
+            }
+
+            const message = msg.message as Record<string, unknown>;
+            if (!('content' in message)) {
+              return false;
+            }
+
+            const content = message.content;
+
+            // type: 'prompt'メッセージのcontentは常に文字列
+            if (typeof content !== 'string') {
+              return false;
+            }
+
+            return content === pendingPrompt;
+          });
+
+          if (matchFound) {
+            // エディタを直接クリア（アクティブタブの場合のみ）
+            if (tab_id === activeTabId) {
+              editorRef.current?.clearEditor();
+            }
+
+            // pendingPromptを削除
+            setPendingPrompts((prev) => {
+              const next = { ...prev };
+              delete next[tab_id];
+              return next;
+            });
+          }
+        }
+      }
 
       // Backend側でマージ・ソート済みなのでそのまま使用
       setTabMessages((prev) => ({ ...prev, [tab_id]: messages }));
@@ -185,6 +239,7 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
       eventSource.removeEventListener('tab:messages:updated', handleTabMessagesUpdated);
       eventSource.removeEventListener('task:updated', handleTaskUpdated);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [eventSource, id, activeTabId, tabs]);
 
   // タブのポーリング（running状態の場合のみ、SSE未接続時のフォールバック）
@@ -295,17 +350,27 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
   // Claude実行
   const handleExecute = async (tab_id: string, prompt: string) => {
     try {
+      // 送信前にプロンプトを記録
+      setPendingPrompts((prev) => ({ ...prev, [tab_id]: prompt }));
+
       const response = await fetch(`/api/tabs/${tab_id}/message`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ message: prompt }),
       });
 
-      if (!response.ok) throw new Error('Failed to execute');
+      if (!response.ok) {
+        // 失敗時は記録を削除
+        setPendingPrompts((prev) => {
+          const next = { ...prev };
+          delete next[tab_id];
+          return next;
+        });
+        throw new Error('Failed to execute');
+      }
 
       // SSE経由でtab:updatedイベントが配信されるため、tabは更新しない
-      // 実行成功後にプロンプトをクリア
-      setPrompts((prev) => ({ ...prev, [tab_id]: '' }));
+      // プロンプトのクリアはSSEイベント受信時に実施（handleTabMessagesUpdated）
     } catch (error) {
       console.error('Failed to execute:', error);
       throw error;
@@ -332,7 +397,7 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
 
   // プロンプト変更
   const handlePromptChange = (tab_id: string, prompt: string) => {
-    setPrompts((prev) => ({ ...prev, [tab_id]: prompt }));
+    setInitialPrompts((prev) => ({ ...prev, [tab_id]: prompt }));
   };
 
   // タスク削除
@@ -440,8 +505,9 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
                 >
                   {(viewMode === 'split' || viewMode === 'editor') && (
                     <ClaudePromptEditor
+                      ref={editorRef}
                       tab={activeTab}
-                      prompt={prompts[activeTab.tab_id] || ''}
+                      initialPrompt={initialPrompts[activeTab.tab_id] || ''}
                       onExecute={handleExecute}
                       onInterrupt={handleInterrupt}
                       onPromptChange={(prompt) => handlePromptChange(activeTab.tab_id, prompt)}

--- a/src/components/ClaudePromptEditor.tsx
+++ b/src/components/ClaudePromptEditor.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Editor } from '@monaco-editor/react';
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useRef, useEffect, useCallback, forwardRef, useImperativeHandle } from 'react';
 import type { editor } from 'monaco-editor';
 import type { Tab } from '@/lib/types';
 import { useTheme } from '@/contexts/ThemeContext';
@@ -9,143 +9,152 @@ import { ClaudeState } from '@/components/ClaudeState';
 import { getClaudeStatus } from '@/lib/claude-status';
 import { Send, Square } from 'lucide-react';
 
+export interface ClaudePromptEditorRef {
+  clearEditor: () => void;
+}
+
 interface ClaudePromptEditorProps {
   tab: Tab;
-  prompt: string;
+  initialPrompt: string;
   onExecute: (tabId: string, prompt: string) => Promise<void>;
   onInterrupt: (tabId: string) => Promise<void>;
   onPromptChange: (prompt: string) => void;
 }
 
-export function ClaudePromptEditor({
-  tab,
-  prompt,
-  onExecute,
-  onInterrupt,
-  onPromptChange,
-}: ClaudePromptEditorProps) {
-  const [isExecuting, setIsExecuting] = useState(false);
-  const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
-  const { effectiveTheme } = useTheme();
+export const ClaudePromptEditor = forwardRef<ClaudePromptEditorRef, ClaudePromptEditorProps>(
+  function ClaudePromptEditor({ tab, initialPrompt, onExecute, onInterrupt, onPromptChange }, ref) {
+    const [isExecuting, setIsExecuting] = useState(false);
+    const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
+    const { effectiveTheme } = useTheme();
 
-  const handleExecute = useCallback(async () => {
-    const prompt = editorRef.current?.getValue() || '';
-    if (!prompt.trim() || isExecuting) return;
-    try {
-      setIsExecuting(true);
-      await onExecute(tab.tab_id, prompt);
-      // 親コンポーネントがpromptsをクリアし、useEffectがエディタを更新
-    } catch (error) {
-      console.error('Failed to execute:', error);
-    } finally {
-      setIsExecuting(false);
-    }
-  }, [isExecuting, onExecute, tab.tab_id]);
+    // 親コンポーネントから呼べるメソッドを公開
+    useImperativeHandle(ref, () => ({
+      clearEditor: () => {
+        if (editorRef.current) {
+          editorRef.current.setValue('');
+        }
+      },
+    }));
 
-  const handleInterrupt = useCallback(async () => {
-    try {
-      await onInterrupt(tab.tab_id);
-    } catch (error) {
-      console.error('Failed to interrupt:', error);
-    }
-  }, [onInterrupt, tab.tab_id]);
-
-  // 常に最新のハンドラーを参照するためのref
-  const handleExecuteRef = useRef(handleExecute);
-  const handleInterruptRef = useRef(handleInterrupt);
-
-  useEffect(() => {
-    handleExecuteRef.current = handleExecute;
-  }, [handleExecute]);
-
-  useEffect(() => {
-    handleInterruptRef.current = handleInterrupt;
-  }, [handleInterrupt]);
-
-  // タブ切り替え時にエディタの内容を更新
-  useEffect(() => {
-    if (editorRef.current) {
-      const currentValue = editorRef.current.getValue();
-      if (currentValue !== prompt) {
-        editorRef.current.setValue(prompt);
+    const handleExecute = useCallback(async () => {
+      const prompt = editorRef.current?.getValue() || '';
+      if (!prompt.trim() || isExecuting) return;
+      try {
+        setIsExecuting(true);
+        await onExecute(tab.tab_id, prompt);
+        // エディタのクリアは親コンポーネントからclearEditor()で実行される
+      } catch (error) {
+        console.error('Failed to execute:', error);
+      } finally {
+        setIsExecuting(false);
       }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tab.tab_id]);
+    }, [isExecuting, onExecute, tab.tab_id]);
 
-  const status = getClaudeStatus(tab);
-  const isRunning = status === 'running';
-  const canExecute = !isExecuting && !isRunning;
+    const handleInterrupt = useCallback(async () => {
+      try {
+        await onInterrupt(tab.tab_id);
+      } catch (error) {
+        console.error('Failed to interrupt:', error);
+      }
+    }, [onInterrupt, tab.tab_id]);
 
-  return (
-    <div className="flex flex-col h-full min-h-0">
-      <div className="flex items-center justify-between mb-2 flex-shrink-0 h-8">
-        <h3 className="text-sm font-semibold text-theme-fg">Prompt</h3>
-        <div className="flex items-center gap-2">
-          <ClaudeState status={status} />
+    // 常に最新のハンドラーを参照するためのref
+    const handleExecuteRef = useRef(handleExecute);
+    const handleInterruptRef = useRef(handleInterrupt);
 
-          {!isRunning && (
-            <button
-              onClick={handleExecute}
-              disabled={!canExecute}
-              className="px-3 py-1 bg-primary text-white rounded text-sm hover:bg-primary-hover disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-primary cursor-pointer flex items-center gap-1"
-            >
-              <Send className="w-3 h-3" />
-              Send
-            </button>
-          )}
+    useEffect(() => {
+      handleExecuteRef.current = handleExecute;
+    }, [handleExecute]);
 
-          {isRunning && (
-            <button
-              onClick={handleInterrupt}
-              className="px-3 py-1 bg-red-700 text-white rounded text-sm hover:bg-red-600 cursor-pointer flex items-center gap-1"
-            >
-              <Square className="w-3 h-3" />
-              Interrupt
-            </button>
-          )}
+    useEffect(() => {
+      handleInterruptRef.current = handleInterrupt;
+    }, [handleInterrupt]);
+
+    // タブ切り替え時にエディタの内容を更新
+    useEffect(() => {
+      if (editorRef.current) {
+        const currentValue = editorRef.current.getValue();
+        if (currentValue !== initialPrompt) {
+          editorRef.current.setValue(initialPrompt);
+        }
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [tab.tab_id]);
+
+    const status = getClaudeStatus(tab);
+    const isRunning = status === 'running';
+    const canExecute = !isExecuting && !isRunning;
+
+    return (
+      <div className="flex flex-col h-full min-h-0">
+        <div className="flex items-center justify-between mb-2 flex-shrink-0 h-8">
+          <h3 className="text-sm font-semibold text-theme-fg">Prompt</h3>
+          <div className="flex items-center gap-2">
+            <ClaudeState status={status} />
+
+            {!isRunning && (
+              <button
+                onClick={handleExecute}
+                disabled={!canExecute}
+                className="px-3 py-1 bg-primary text-white rounded text-sm hover:bg-primary-hover disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-primary cursor-pointer flex items-center gap-1"
+              >
+                <Send className="w-3 h-3" />
+                Send
+              </button>
+            )}
+
+            {isRunning && (
+              <button
+                onClick={handleInterrupt}
+                className="px-3 py-1 bg-red-700 text-white rounded text-sm hover:bg-red-600 cursor-pointer flex items-center gap-1"
+              >
+                <Square className="w-3 h-3" />
+                Interrupt
+              </button>
+            )}
+          </div>
+        </div>
+
+        <div className="flex-1 min-h-0 border border-theme rounded overflow-hidden">
+          <Editor
+            height="100%"
+            defaultLanguage="markdown"
+            defaultValue=""
+            onMount={async (editor) => {
+              editorRef.current = editor;
+              // マウント時に初期値を設定
+              if (initialPrompt) {
+                editor.setValue(initialPrompt);
+              }
+
+              // monaco-editorの型をインポート
+              const monaco = await import('monaco-editor');
+
+              // Cmd+Enter (Mac) / Ctrl+Enter (Windows/Linux) で Send
+              editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, () => {
+                handleExecuteRef.current();
+              });
+
+              // Esc で Interrupt
+              editor.addCommand(monaco.KeyCode.Escape, () => {
+                handleInterruptRef.current();
+              });
+            }}
+            onChange={(value) => {
+              onPromptChange(value || '');
+            }}
+            options={{
+              minimap: { enabled: false },
+              lineNumbers: 'on',
+              wordWrap: 'on',
+              fontSize: 14,
+              scrollBeyondLastLine: false,
+              readOnly: false,
+            }}
+            theme={effectiveTheme === 'dark' ? 'vs-dark' : 'vs-light'}
+          />
         </div>
       </div>
-
-      <div className="flex-1 min-h-0 border border-theme rounded overflow-hidden">
-        <Editor
-          height="100%"
-          defaultLanguage="markdown"
-          defaultValue=""
-          onMount={async (editor) => {
-            editorRef.current = editor;
-            // マウント時に初期値を設定
-            if (prompt) {
-              editor.setValue(prompt);
-            }
-
-            // monaco-editorの型をインポート
-            const monaco = await import('monaco-editor');
-
-            // Cmd+Enter (Mac) / Ctrl+Enter (Windows/Linux) で Send
-            editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, () => {
-              handleExecuteRef.current();
-            });
-
-            // Esc で Interrupt
-            editor.addCommand(monaco.KeyCode.Escape, () => {
-              handleInterruptRef.current();
-            });
-          }}
-          onChange={(value) => {
-            onPromptChange(value || '');
-          }}
-          options={{
-            minimap: { enabled: false },
-            lineNumbers: 'on',
-            wordWrap: 'on',
-            fontSize: 14,
-            scrollBeyondLastLine: false,
-            readOnly: isRunning,
-          }}
-          theme={effectiveTheme === 'dark' ? 'vs-dark' : 'vs-light'}
-        />
-      </div>
-    </div>
-  );
-}
+    );
+  }
+);

--- a/src/lib/tab-repository.ts
+++ b/src/lib/tab-repository.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
-import type { SessionData } from './types';
+import type { SessionData, MergedMessage, SimplifiedUserMessage } from './types';
 
 const SESSIONS_FILE = path.join(os.homedir(), '.tsunagi', 'state', 'sessions.json');
 
@@ -165,13 +165,16 @@ export async function appendUserPrompt(
  * タブのマージ済みメッセージを取得
  * userPromptsとrawMessagesをマージし、タイムスタンプでソート
  */
-export async function getMergedMessages(tab_id: string): Promise<unknown[]> {
+export async function getMergedMessages(tab_id: string): Promise<MergedMessage[]> {
   const sessionData = await getSessionData(tab_id);
   if (!sessionData) return [];
 
-  // UserPromptをSDK user message形式に変換
-  const userMessages = sessionData.userPrompts.map((up, index) => ({
-    type: 'user',
+  // UserPromptをpromptメッセージ形式に変換
+  const userMessages: (SimplifiedUserMessage & {
+    _sourceIndex: number;
+    _source: 'userPrompt';
+  })[] = sessionData.userPrompts.map((up, index) => ({
+    type: 'prompt' as const,
     created_at: up.created_at,
     message: { content: up.prompt },
     _sourceIndex: index,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -43,6 +43,22 @@ export interface SessionData {
 }
 
 // ============================================
+// Merged Message型（getMergedMessagesの返り値）
+// ============================================
+
+// UserPromptから変換されたメッセージ
+export interface SimplifiedUserMessage {
+  type: 'prompt';
+  created_at: string;
+  message: { content: string };
+}
+
+// getMergedMessagesが返すメッセージ型
+// - SimplifiedUserMessage: userPromptsから変換されたメッセージ
+// - unknown: rawMessagesからのSDKメッセージ（SDKMessage型だが、型定義をimportせずにunknownとする）
+export type MergedMessage = SimplifiedUserMessage | Record<string, unknown>;
+
+// ============================================
 // UIMessage型（新しいデータモデル）
 // ============================================
 

--- a/src/lib/ui-message-converter.ts
+++ b/src/lib/ui-message-converter.ts
@@ -32,6 +32,13 @@ interface SDKToolUseBlock extends SDKContentBlock {
   input: Record<string, unknown>;
 }
 
+interface SDKPromptMessage extends SDKMessageBase {
+  type: 'prompt';
+  message: {
+    content: string;
+  };
+}
+
 interface SDKUserMessage extends SDKMessageBase {
   type: 'user';
   message: {
@@ -70,7 +77,12 @@ interface SDKResultMessage extends SDKMessageBase {
   };
 }
 
-type SDKMessage = SDKUserMessage | SDKAssistantMessage | SDKSystemMessage | SDKResultMessage;
+type SDKMessage =
+  | SDKPromptMessage
+  | SDKUserMessage
+  | SDKAssistantMessage
+  | SDKSystemMessage
+  | SDKResultMessage;
 
 /**
  * Claude SDKのraw messagesをUI表示用のUIMessagesに変換するクラス
@@ -89,6 +101,12 @@ export class UIMessageConverter {
       if (!msg || !msg.type) continue;
 
       switch (msg.type) {
+        case 'prompt': {
+          const promptMsg = msg as SDKPromptMessage;
+          uiMessages.push(this.convertPromptMessage(promptMsg));
+          break;
+        }
+
         case 'user': {
           const userMsg = msg as SDKUserMessage;
           // Skip tool_result messages (they will be processed separately)
@@ -205,6 +223,25 @@ export class UIMessageConverter {
         }
       }
     }
+  }
+
+  private convertPromptMessage(msg: SDKPromptMessage): UIMessage {
+    // PromptメッセージはuserPromptsから生成され、contentは常に文字列
+    const text = msg.message.content;
+
+    return {
+      id: uuidv4(),
+      timestamp: msg.created_at || new Date().toISOString(),
+      type: 'user_message',
+      content: {
+        type: 'user_message',
+        text,
+      },
+      metadata: {
+        sdkMessageUuids: msg.uuid ? [msg.uuid] : [],
+        role: 'user',
+      },
+    };
   }
 
   private convertUserMessage(msg: SDKUserMessage): UIMessage {


### PR DESCRIPTION
- Change userPrompts message type from 'user' to 'prompt' to distinguish from SDK messages
- Implement prompt tracking with pendingPrompts state to match sent messages
- Use useImperativeHandle to expose clearEditor method from ClaudePromptEditor
- Rename 'prompts' to 'initialPrompts' to clarify uncontrolled MonacoEditor behavior
- Clear editor by calling editorRef.current.clearEditor() when type: 'prompt' message is detected
- Remove readOnly restriction to allow editing during Claude execution
- Add type safety with MergedMessage and SimplifiedUserMessage types