### PR TITLE
feat: add Claude Agent SDK settings sources configuration

### DIFF
--- a/src/app/api/claude-settings/route.ts
+++ b/src/app/api/claude-settings/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from 'next/server';
+import * as settingsRepo from '@/lib/claude-settings-repository';
+
+/**
+ * GET /api/claude-settings?scope=xxx&owner=xxx&repo=xxx
+ * 設定を取得
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const scope = searchParams.get('scope') as 'global' | 'owner' | 'repo' | null;
+    const owner = searchParams.get('owner');
+    const repo = searchParams.get('repo');
+
+    if (!scope) {
+      return NextResponse.json({ error: 'scope parameter is required' }, { status: 400 });
+    }
+
+    const sources = await settingsRepo.getSettingSources(
+      scope,
+      owner || undefined,
+      repo || undefined
+    );
+
+    return NextResponse.json({ data: { sources } });
+  } catch (error) {
+    console.error('[API] Failed to get claude settings:', error);
+    return NextResponse.json({ error: 'Failed to get claude settings' }, { status: 500 });
+  }
+}
+
+/**
+ * POST /api/claude-settings
+ * 設定を保存
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { scope, sources, owner, repo } = body;
+
+    if (!scope || !Array.isArray(sources)) {
+      return NextResponse.json({ error: 'scope and sources are required' }, { status: 400 });
+    }
+
+    // sourcesの検証
+    const validSources = ['user', 'project', 'local'];
+    if (!sources.every((s) => validSources.includes(s))) {
+      return NextResponse.json({ error: 'Invalid sources value' }, { status: 400 });
+    }
+
+    await settingsRepo.setSettingSources(scope, sources, owner, repo);
+
+    return NextResponse.json({ data: { success: true } }, { status: 201 });
+  } catch (error) {
+    console.error('[API] Failed to set claude settings:', error);
+    return NextResponse.json({ error: 'Failed to set claude settings' }, { status: 500 });
+  }
+}
+
+/**
+ * DELETE /api/claude-settings?scope=xxx&owner=xxx&repo=xxx
+ * 設定を削除
+ */
+export async function DELETE(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const scope = searchParams.get('scope') as 'global' | 'owner' | 'repo' | null;
+    const owner = searchParams.get('owner');
+    const repo = searchParams.get('repo');
+
+    if (!scope) {
+      return NextResponse.json({ error: 'scope parameter is required' }, { status: 400 });
+    }
+
+    await settingsRepo.deleteSettingSources(scope, owner || undefined, repo || undefined);
+
+    return NextResponse.json({ data: { success: true } });
+  } catch (error) {
+    console.error('[API] Failed to delete claude settings:', error);
+    return NextResponse.json({ error: 'Failed to delete claude settings' }, { status: 500 });
+  }
+}

--- a/src/app/api/tabs/[tab_id]/message/route.ts
+++ b/src/app/api/tabs/[tab_id]/message/route.ts
@@ -92,6 +92,8 @@ export async function POST(request: NextRequest, { params }: Params) {
       workingDirectory,
       env,
       agentSessionId: tab.session_id,
+      owner: task.owner,
+      repo: task.repo,
       onRawMessage: async (rawMessage: unknown) => {
         // Raw messageをsessions.jsonに追加
         await tabRepo.appendMessage(tab_id, rawMessage);

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -6,6 +6,7 @@ import { ArrowLeft } from 'lucide-react';
 import { EnvTreeNavigation, type SelectedNode } from '@/components/env/EnvTreeNavigation';
 import { EnvVariableEditor } from '@/components/env/EnvVariableEditor';
 import { ClaudeTokenSection } from '@/components/env/ClaudeTokenSection';
+import { ClaudeSettingsEditor } from '@/components/settings/ClaudeSettingsEditor';
 
 export default function SettingsPage() {
   const router = useRouter();
@@ -105,6 +106,9 @@ export default function SettingsPage() {
                 onboardingStatus={onboardingStatus}
                 onSwitchToGlobal={handleSwitchToGlobal}
               />
+
+              {/* Claude Settings Sources Section (Global scope only) */}
+              {selectedNode.scope === 'global' && <ClaudeSettingsEditor scope="global" />}
 
               {/* Environment Variables Section */}
               <EnvVariableEditor selectedNode={selectedNode} />

--- a/src/components/settings/ClaudeSettingsEditor.tsx
+++ b/src/components/settings/ClaudeSettingsEditor.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Settings, Info } from 'lucide-react';
+
+interface ClaudeSettingsEditorProps {
+  scope: 'global' | 'owner' | 'repo';
+  owner?: string;
+  repo?: string;
+}
+
+export function ClaudeSettingsEditor({ scope, owner, repo }: ClaudeSettingsEditorProps) {
+  const [sources, setSources] = useState<Array<'user' | 'project' | 'local'>>([]);
+  const [loading, setLoading] = useState(true);
+
+  // 初期ロード
+  useEffect(() => {
+    const loadSettings = async () => {
+      try {
+        const params = new URLSearchParams({ scope });
+        if (owner) params.append('owner', owner);
+        if (repo) params.append('repo', repo);
+
+        const response = await fetch(`/api/claude-settings?${params}`);
+        const data = await response.json();
+
+        if (data.data.sources) {
+          setSources(data.data.sources);
+        }
+      } catch (error) {
+        console.error('Failed to load claude settings:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadSettings();
+  }, [scope, owner, repo]);
+
+  // チェックボックス変更ハンドラ
+  const handleToggle = async (source: 'user' | 'project' | 'local', checked: boolean) => {
+    try {
+      let newSources: Array<'user' | 'project' | 'local'>;
+
+      if (checked) {
+        newSources = [...sources, source];
+      } else {
+        newSources = sources.filter((s) => s !== source);
+      }
+
+      // 楽観的更新
+      setSources(newSources);
+
+      // サーバーに保存
+      const response = await fetch('/api/claude-settings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ scope, sources: newSources, owner, repo }),
+      });
+
+      if (!response.ok) {
+        // エラー時は元に戻す
+        setSources(sources);
+        console.error('Failed to update claude settings');
+      }
+    } catch (error) {
+      // エラー時は元に戻す
+      setSources(sources);
+      console.error('Failed to update claude settings:', error);
+    }
+  };
+
+  if (loading) {
+    return <div className="text-theme-muted text-sm">Loading...</div>;
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <Settings className="w-5 h-5 text-primary-light" />
+        <h3 className="text-lg font-semibold text-theme-fg">Claude Settings Sources</h3>
+      </div>
+
+      <div className="bg-theme-card-hover border border-theme rounded p-4 space-y-3">
+        {/* 説明 */}
+        <div className="flex gap-2 text-sm text-theme-muted">
+          <Info className="w-4 h-4 mt-0.5 flex-shrink-0" />
+          <p>
+            設定ファイル（.mcp.json、CLAUDE.md、.claude/settings.json）の読み込み方法を選択します。
+            すべて無効の場合、isolationモードで実行されます。
+          </p>
+        </div>
+
+        {/* チェックボックス */}
+        <div className="space-y-2">
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={sources.includes('user')}
+              onChange={(e) => handleToggle('user', e.target.checked)}
+              className="w-4 h-4 rounded border-theme-border"
+            />
+            <span className="text-theme-fg">
+              User settings{' '}
+              <span className="text-theme-muted text-sm">(~/.claude/settings.json)</span>
+            </span>
+          </label>
+
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={sources.includes('project')}
+              onChange={(e) => handleToggle('project', e.target.checked)}
+              className="w-4 h-4 rounded border-theme-border"
+            />
+            <span className="text-theme-fg">
+              Project settings{' '}
+              <span className="text-theme-muted text-sm">
+                (.claude/settings.json, CLAUDE.md, .mcp.json)
+              </span>
+            </span>
+          </label>
+
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={sources.includes('local')}
+              onChange={(e) => handleToggle('local', e.target.checked)}
+              className="w-4 h-4 rounded border-theme-border"
+            />
+            <span className="text-theme-fg">
+              Local settings{' '}
+              <span className="text-theme-muted text-sm">(.claude/settings.local.json)</span>
+            </span>
+          </label>
+        </div>
+
+        {/* 現在の状態表示 */}
+        <div className="mt-4 pt-4 border-t border-theme">
+          <p className="text-sm text-theme-muted">
+            {sources.length === 0 ? (
+              <span className="text-yellow-500 font-medium">
+                Isolation mode (設定ファイルを読み込みません)
+              </span>
+            ) : (
+              <>
+                有効な設定:{' '}
+                <span className="text-primary-light font-medium">{sources.join(', ')}</span>
+              </>
+            )}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/claude-client.ts
+++ b/src/lib/claude-client.ts
@@ -1,4 +1,5 @@
 import { query, type Query } from '@anthropic-ai/claude-agent-sdk';
+import * as settingsRepo from './claude-settings-repository';
 
 export interface ExecuteOptions {
   sessionId: string;
@@ -9,6 +10,8 @@ export interface ExecuteOptions {
   onRawMessage?: (message: unknown) => void; // Raw messagesの永続化用
   onStatusChange?: (status: 'running' | 'success' | 'error') => void;
   onAgentSessionId?: (agentSessionId: string) => void;
+  owner?: string; // タスクのowner
+  repo?: string; // タスクのrepo
 }
 
 /**
@@ -29,10 +32,23 @@ export async function executeSession(options: ExecuteOptions): Promise<void> {
     onRawMessage,
     onStatusChange,
     onAgentSessionId,
+    owner,
+    repo,
   } = options;
 
   try {
     onStatusChange?.('running');
+
+    // settingSourcesをプロジェクト設定から取得
+    let settingSources: Array<'user' | 'project' | 'local'> | undefined;
+
+    if (owner && repo) {
+      const resolvedSettings = await settingsRepo.resolveSettings({ owner, repo });
+      settingSources = resolvedSettings.settingSources;
+    } else {
+      // owner/repoが指定されていない場合はglobal設定を使用
+      settingSources = await settingsRepo.getSettingSources('global');
+    }
 
     // Build query options
     const queryOptions: {
@@ -42,6 +58,7 @@ export async function executeSession(options: ExecuteOptions): Promise<void> {
       permissionMode?: 'bypassPermissions';
       allowDangerouslySkipPermissions?: boolean;
       bypassPermissions?: boolean;
+      settingSources?: Array<'user' | 'project' | 'local'>;
     } = {
       cwd: workingDirectory,
       permissionMode:
@@ -50,6 +67,7 @@ export async function executeSession(options: ExecuteOptions): Promise<void> {
           : undefined,
       allowDangerouslySkipPermissions: process.env.CLAUDE_BYPASS_PERMISSIONS !== 'false',
       bypassPermissions: process.env.CLAUDE_BYPASS_PERMISSIONS !== 'false',
+      settingSources, // 追加（undefinedの場合はisolationモード）
     };
 
     // Merge custom env with system environment to ensure node and other binaries are accessible
@@ -96,6 +114,7 @@ export async function executeSession(options: ExecuteOptions): Promise<void> {
         allowDangerouslySkipPermissions: queryOptions.allowDangerouslySkipPermissions,
         bypassPermissions: queryOptions.bypassPermissions,
         hasResume: !!queryOptions.resume,
+        settingSources: queryOptions.settingSources,
       });
     }
 

--- a/src/lib/claude-settings-repository.ts
+++ b/src/lib/claude-settings-repository.ts
@@ -1,0 +1,206 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+import type { ClaudeSettingSources, SettingSource, ResolvedSettings } from './types';
+import * as envRepo from './env-repository';
+
+// 保存先: ~/.tsunagi/state/claude-settings.json
+const SETTINGS_FILE = path.join(os.homedir(), '.tsunagi', 'state', 'claude-settings.json');
+
+// キュー機構（env-repository.tsと同様）
+class Queue {
+  private queue: (() => Promise<void>)[] = [];
+  private running = false;
+
+  async add<T>(fn: () => Promise<T>): Promise<T> {
+    return new Promise((resolve, reject) => {
+      this.queue.push(async () => {
+        try {
+          const result = await fn();
+          resolve(result);
+        } catch (error) {
+          reject(error);
+        }
+      });
+      this.run();
+    });
+  }
+
+  private async run() {
+    if (this.running) return;
+    this.running = true;
+
+    while (this.queue.length > 0) {
+      const fn = this.queue.shift();
+      if (fn) await fn();
+    }
+
+    this.running = false;
+  }
+}
+
+const queue = new Queue();
+
+// 読み込み処理
+async function readSettings(): Promise<ClaudeSettingSources[]> {
+  try {
+    const data = await fs.readFile(SETTINGS_FILE, 'utf-8');
+    return JSON.parse(data) as ClaudeSettingSources[];
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return [];
+    }
+    throw error;
+  }
+}
+
+// 書き込み処理（原子的）
+async function writeSettings(settings: ClaudeSettingSources[]): Promise<void> {
+  const dir = path.dirname(SETTINGS_FILE);
+  await fs.mkdir(dir, { recursive: true });
+
+  const tmpFile = `${SETTINGS_FILE}.tmp`;
+  await fs.writeFile(tmpFile, JSON.stringify(settings, null, 2), 'utf-8');
+  await fs.rename(tmpFile, SETTINGS_FILE);
+}
+
+/**
+ * 設定の取得（優先順位: repo > owner > global）
+ */
+export async function getSettingSources(
+  scope: 'global' | 'owner' | 'repo',
+  owner?: string,
+  repo?: string
+): Promise<SettingSource[] | undefined> {
+  return queue.add(async () => {
+    const allSettings = await readSettings();
+    let result: ClaudeSettingSources | undefined;
+
+    // repo スコープの設定を優先
+    if (scope === 'repo' && owner && repo) {
+      result = allSettings.find(
+        (s) => s.scope === 'repo' && s.owner === owner && s.repo === repo && s.enabled
+      );
+    }
+
+    // owner スコープの設定を次に優先
+    if (!result && (scope === 'owner' || scope === 'repo') && owner) {
+      result = allSettings.find((s) => s.scope === 'owner' && s.owner === owner && s.enabled);
+    }
+
+    // global スコープの設定を最後に使用
+    if (!result) {
+      result = allSettings.find((s) => s.scope === 'global' && s.enabled);
+    }
+
+    // 設定が見つからない、またはsourcesが空の場合はundefined（isolationモード）
+    return result && result.sources.length > 0 ? result.sources : undefined;
+  });
+}
+
+/**
+ * 設定の保存
+ */
+export async function setSettingSources(
+  scope: 'global' | 'owner' | 'repo',
+  sources: SettingSource[],
+  owner?: string,
+  repo?: string
+): Promise<void> {
+  return queue.add(async () => {
+    const allSettings = await readSettings();
+
+    const newSetting: ClaudeSettingSources = {
+      scope,
+      owner,
+      repo,
+      sources,
+      enabled: true,
+    };
+
+    // 既存の設定を検索
+    const existingIndex = allSettings.findIndex((s) => {
+      if (s.scope === 'global') return scope === 'global';
+      if (s.scope === 'owner') return scope === 'owner' && s.owner === owner;
+      if (s.scope === 'repo') return scope === 'repo' && s.owner === owner && s.repo === repo;
+      return false;
+    });
+
+    if (existingIndex >= 0) {
+      allSettings[existingIndex] = newSetting;
+    } else {
+      allSettings.push(newSetting);
+    }
+
+    await writeSettings(allSettings);
+  });
+}
+
+/**
+ * 設定の削除
+ */
+export async function deleteSettingSources(
+  scope: 'global' | 'owner' | 'repo',
+  owner?: string,
+  repo?: string
+): Promise<void> {
+  return queue.add(async () => {
+    let allSettings = await readSettings();
+
+    allSettings = allSettings.filter((s) => {
+      if (scope === 'global') return s.scope !== 'global';
+      if (scope === 'owner') return !(s.scope === 'owner' && s.owner === owner);
+      if (scope === 'repo') return !(s.scope === 'repo' && s.owner === owner && s.repo === repo);
+      return true;
+    });
+
+    await writeSettings(allSettings);
+  });
+}
+
+/**
+ * 設定の有効/無効切り替え
+ */
+export async function toggleSettingSources(
+  scope: 'global' | 'owner' | 'repo',
+  enabled: boolean,
+  owner?: string,
+  repo?: string
+): Promise<void> {
+  return queue.add(async () => {
+    const allSettings = await readSettings();
+
+    const setting = allSettings.find((s) => {
+      if (scope === 'global') return s.scope === 'global';
+      if (scope === 'owner') return s.scope === 'owner' && s.owner === owner;
+      if (scope === 'repo') return s.scope === 'repo' && s.owner === owner && s.repo === repo;
+      return false;
+    });
+
+    if (setting) {
+      setting.enabled = enabled;
+      await writeSettings(allSettings);
+    }
+  });
+}
+
+/**
+ * resolveSettings: プロジェクト固有の設定を解決（環境変数も含む）
+ */
+export async function resolveSettings(params: {
+  owner: string;
+  repo: string;
+}): Promise<ResolvedSettings> {
+  const { owner, repo } = params;
+
+  // settingSourcesを取得
+  const settingSources = await getSettingSources('repo', owner, repo);
+
+  // 環境変数を取得（Claude Tokenを含む）
+  const env = await envRepo.getEnv('repo', owner, repo);
+
+  return {
+    settingSources,
+    env,
+  };
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -173,6 +173,23 @@ export interface EnvironmentVariable {
   enabled: boolean; // 有効/無効フラグ（デフォルトtrue）
 }
 
+// Claude Agent SDK Settings Sources設定
+export type SettingSource = 'user' | 'project' | 'local';
+
+export interface ClaudeSettingSources {
+  scope: 'global' | 'owner' | 'repo';
+  owner?: string;
+  repo?: string;
+  sources: SettingSource[]; // ['user', 'project', 'local']の組み合わせ
+  enabled: boolean; // 有効/無効フラグ
+}
+
+// resolveSettings関数の戻り値型
+export interface ResolvedSettings {
+  settingSources?: SettingSource[]; // undefinedの場合はisolationモード
+  env: Record<string, string>; // 環境変数（Claude Tokenを含む）
+}
+
 // API Request/Response型
 export interface ApiResponse<T> {
   data: T;


### PR DESCRIPTION
Add support for configuring Claude Agent SDK settings sources (.mcp.json, CLAUDE.md, .claude/settings.json) with UI controls and project-scoped resolution.

- Add ClaudeSettingSources data model with scope-based configuration
- Implement claude-settings-repository for managing settings sources
- Add resolveSettings function to fetch both settings and environment variables
- Create /api/claude-settings endpoints (GET/POST/DELETE)
- Update claude-client to use settingSources parameter
- Add ClaudeSettingsEditor UI component for Global scope settings
- Support isolation mode when settingSources is undefined
- Pass owner/repo to executeSession for project-scoped settings