### PR TITLE
fix: correct repository filter to show only registered repositories

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -51,17 +51,6 @@ export default function Home() {
     return { state, nextStep };
   }, [repositories, globalEnv, tasks]);
 
-  // Extract unique owners and repos from repositories
-  const owners = useMemo(() => {
-    const uniqueOwners = [...new Set(repositories.map((r) => r.owner))];
-    return uniqueOwners;
-  }, [repositories]);
-
-  const repos = useMemo(() => {
-    const uniqueRepos = [...new Set(repositories.map((r) => r.repo))];
-    return uniqueRepos;
-  }, [repositories]);
-
   // Filter tasks
   const filteredTasks = useMemo(() => {
     return tasks.filter((task) => {
@@ -239,8 +228,7 @@ export default function Home() {
         onSettingsClick={() => router.push('/settings')}
         onReload={loadData}
         nextStep={onboardingState.nextStep}
-        owners={owners}
-        repos={repos}
+        repositories={repositories}
         onFilterChange={handleFilterChange}
         isCloneDialogOpen={isCloneDialogOpen}
       />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,8 +9,7 @@ interface HeaderProps {
   onSettingsClick: () => void;
   onReload: () => void;
   nextStep?: 'clone' | 'env' | 'task' | 'complete';
-  owners: string[];
-  repos: string[];
+  repositories: Array<{ owner: string; repo: string }>;
   onFilterChange: (filters: { owner: string; repo: string; search: string }) => void;
   isCloneDialogOpen?: boolean;
 }
@@ -20,8 +19,7 @@ export function Header({
   onSettingsClick,
   onReload,
   nextStep = 'complete',
-  owners,
-  repos,
+  repositories,
   onFilterChange,
   isCloneDialogOpen = false,
 }: HeaderProps) {
@@ -48,9 +46,10 @@ export function Header({
   }, [isFilterOpen]);
 
   // Create combined owner/repo list
-  const repoOptions = owners.flatMap((owner) =>
-    repos.map((repo) => ({ value: `${owner}/${repo}`, label: `${owner}/${repo}` }))
-  );
+  const repoOptions = repositories.map((repository) => ({
+    value: `${repository.owner}/${repository.repo}`,
+    label: `${repository.owner}/${repository.repo}`,
+  }));
 
   const handleRepoChange = (value: string) => {
     setRepoFilter(value);


### PR DESCRIPTION
Changed repository filter implementation to pass actual repository objects instead of creating cartesian product of owners and repos arrays, fixing the issue where 4 options were shown instead of the correct 2.