### PR TITLE
feat: group consecutive tool_use messages with accordion display

### DIFF
--- a/src/components/ExecutionLogsChat.tsx
+++ b/src/components/ExecutionLogsChat.tsx
@@ -2,7 +2,17 @@
 
 import { useEffect, useRef, useState, useMemo } from 'react';
 import ReactMarkdown from 'react-markdown';
-import { ChevronDown, ChevronUp, Brain, Wrench, Info, XCircle, Loader2, Ban } from 'lucide-react';
+import {
+  ChevronDown,
+  ChevronUp,
+  Brain,
+  Wrench,
+  Info,
+  XCircle,
+  Loader2,
+  Ban,
+  CircleCheck,
+} from 'lucide-react';
 import type { UIMessage } from '@/lib/types';
 import { UIMessageConverter } from '@/lib/ui-message-converter';
 import { useTheme } from '@/contexts/ThemeContext';
@@ -101,6 +111,15 @@ export function ExecutionLogsChat({ rawMessages, tabId }: ExecutionLogsChatProps
       </div>
     </div>
   );
+}
+
+// グループステータス判定ヘルパー関数
+function getGroupStatus(executions: { status: string }[]) {
+  const hasRunning = executions.some((e) => e.status === 'pending');
+  const hasError = executions.some((e) => e.status === 'error');
+  const allCompleted = executions.every((e) => e.status === 'success' || e.status === 'error');
+
+  return { hasRunning, hasError, allCompleted };
 }
 
 // UIMessage用のコンポーネント
@@ -282,6 +301,22 @@ function UIMessageItem({
             const isGroupExpanded = expandedTools[groupKey] ?? false;
             const executions = block.executions;
 
+            // グループ全体のステータスを判定
+            const groupStatus = getGroupStatus(executions);
+
+            // グループ全体のステータスアイコン
+            const groupStatusIcon = groupStatus.hasRunning ? (
+              sessionCompleted ? (
+                <Ban className="w-3 h-3" />
+              ) : (
+                <Loader2 className="w-3 h-3 animate-spin" />
+              )
+            ) : groupStatus.hasError ? (
+              <XCircle className="w-3 h-3" />
+            ) : groupStatus.allCompleted ? (
+              <CircleCheck className="w-3 h-3" />
+            ) : null;
+
             return (
               <div key={index}>
                 <div className="flex justify-start items-center gap-2">
@@ -304,6 +339,11 @@ function UIMessageItem({
                       >
                         Tool Uses ({executions.length})
                       </span>
+                      {groupStatusIcon && (
+                        <span className={`${isDark ? 'text-purple-300' : 'text-purple-950'}`}>
+                          {groupStatusIcon}
+                        </span>
+                      )}
                       {isGroupExpanded ? (
                         <ChevronUp
                           className={`w-3 h-3 ${isDark ? 'text-purple-300' : 'text-purple-950'}`}

--- a/src/components/ExecutionLogsChat.tsx
+++ b/src/components/ExecutionLogsChat.tsx
@@ -277,6 +277,145 @@ function UIMessageItem({
             );
           }
 
+          if (block.type === 'tool_use_group') {
+            const groupKey = `${message.id}-group-${index}`;
+            const isGroupExpanded = expandedTools[groupKey] ?? false;
+            const executions = block.executions;
+
+            return (
+              <div key={index}>
+                <div className="flex justify-start items-center gap-2">
+                  <div
+                    className={`inline-block text-left rounded-lg p-2 max-w-full ${
+                      isDark ? 'bg-purple-900/20' : 'bg-purple-50'
+                    }`}
+                  >
+                    <button
+                      onClick={() =>
+                        setExpandedTools((prev) => ({ ...prev, [groupKey]: !isGroupExpanded }))
+                      }
+                      className="flex items-center gap-1 hover:opacity-70 w-full text-left cursor-pointer"
+                    >
+                      <Wrench className="w-3 h-3" />
+                      <span
+                        className={`text-xs font-medium ${
+                          isDark ? 'text-purple-300' : 'text-purple-950'
+                        }`}
+                      >
+                        Tool Uses ({executions.length})
+                      </span>
+                      {isGroupExpanded ? (
+                        <ChevronUp
+                          className={`w-3 h-3 ${isDark ? 'text-purple-300' : 'text-purple-950'}`}
+                        />
+                      ) : (
+                        <ChevronDown
+                          className={`w-3 h-3 ${isDark ? 'text-purple-300' : 'text-purple-950'}`}
+                        />
+                      )}
+                    </button>
+
+                    {isGroupExpanded && (
+                      <div className="mt-2 space-y-2">
+                        {executions.map((exec, execIndex) => {
+                          const toolKey = `${groupKey}-${execIndex}`;
+                          const isToolExpanded = expandedTools[toolKey] ?? false;
+                          const hasDetails = Boolean(exec.input) || Boolean(exec.result);
+
+                          // Status icon for pending state
+                          const statusIcon =
+                            exec.status === 'pending' ? (
+                              sessionCompleted ? (
+                                <Ban className="w-3 h-3" />
+                              ) : (
+                                <Loader2 className="w-3 h-3 animate-spin" />
+                              )
+                            ) : null;
+
+                          return (
+                            <div
+                              key={execIndex}
+                              className={`p-2 rounded ${isDark ? 'bg-gray-800/50' : 'bg-white/50'}`}
+                            >
+                              {hasDetails ? (
+                                <button
+                                  onClick={() =>
+                                    setExpandedTools((prev) => ({
+                                      ...prev,
+                                      [toolKey]: !isToolExpanded,
+                                    }))
+                                  }
+                                  className="flex items-center gap-1 hover:opacity-70 w-full text-left cursor-pointer"
+                                >
+                                  <span
+                                    className={`text-xs font-medium ${
+                                      isDark ? 'text-purple-300' : 'text-purple-950'
+                                    }`}
+                                  >
+                                    {exec.toolName}
+                                  </span>
+                                  {statusIcon && (
+                                    <span
+                                      className={`${isDark ? 'text-purple-300' : 'text-purple-950'}`}
+                                    >
+                                      {statusIcon}
+                                    </span>
+                                  )}
+                                  {isToolExpanded ? (
+                                    <ChevronUp
+                                      className={`w-3 h-3 ${isDark ? 'text-purple-300' : 'text-purple-950'}`}
+                                    />
+                                  ) : (
+                                    <ChevronDown
+                                      className={`w-3 h-3 ${isDark ? 'text-purple-300' : 'text-purple-950'}`}
+                                    />
+                                  )}
+                                </button>
+                              ) : (
+                                <div
+                                  className={`text-xs font-medium flex items-center gap-1 ${
+                                    isDark ? 'text-purple-300' : 'text-purple-950'
+                                  }`}
+                                >
+                                  {exec.toolName}
+                                  {statusIcon}
+                                </div>
+                              )}
+                              {isToolExpanded && exec.input && (
+                                <pre
+                                  className={`text-xs p-2 rounded overflow-x-auto mt-2 ${
+                                    isDark ? 'bg-gray-900' : 'bg-gray-50'
+                                  }`}
+                                >
+                                  {JSON.stringify(exec.input, null, 2)}
+                                </pre>
+                              )}
+                              {isToolExpanded && exec.result && (
+                                <div
+                                  className={`text-xs mt-2 p-2 rounded break-words overflow-wrap-anywhere ${
+                                    exec.status === 'error'
+                                      ? isDark
+                                        ? 'bg-red-900/20 text-red-300'
+                                        : 'bg-red-50 text-red-800'
+                                      : isDark
+                                        ? 'bg-green-900/20 text-green-300'
+                                        : 'bg-green-50 text-green-800'
+                                  }`}
+                                >
+                                  {exec.status === 'success' ? '✓' : '✗'} {exec.result}
+                                </div>
+                              )}
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            );
+          }
+
           return null;
         })}
         <div className="text-xs text-theme-muted mt-1">

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -103,7 +103,8 @@ export interface AssistantMessageContent {
 export type AssistantMessageBlock =
   | { type: 'thinking'; content: string; isRedacted?: boolean }
   | { type: 'text'; content: string }
-  | { type: 'tool_use'; info: ToolExecution };
+  | { type: 'tool_use'; info: ToolExecution }
+  | { type: 'tool_use_group'; executions: ToolExecution[] };
 
 // ツール実行グループ（複数のツール実行を1ブロックに集約）
 export interface ToolExecutionGroupContent {

--- a/src/lib/ui-message-converter.ts
+++ b/src/lib/ui-message-converter.ts
@@ -89,11 +89,125 @@ type SDKMessage =
  */
 export class UIMessageConverter {
   /**
+   * assistantメッセージがtool_useのみで構成されているかチェック
+   */
+  private isToolUseOnlyMessage(msg: SDKAssistantMessage): boolean {
+    if (!msg.message || !Array.isArray(msg.message.content)) {
+      return false;
+    }
+    const content = msg.message.content;
+    if (content.length === 0) {
+      return false;
+    }
+    // すべてのブロックがtool_useである場合のみtrue
+    return content.every((block) => block.type === 'tool_use');
+  }
+
+  /**
+   * assistantメッセージからToolExecution配列を抽出
+   */
+  private extractToolExecutions(msg: SDKAssistantMessage): ToolExecution[] {
+    const executions: ToolExecution[] = [];
+    if (!msg.message || !Array.isArray(msg.message.content)) {
+      return executions;
+    }
+
+    for (const block of msg.message.content) {
+      if (block.type === 'tool_use') {
+        const toolUseBlock = block as SDKToolUseBlock;
+        executions.push({
+          id: toolUseBlock.id,
+          toolName: toolUseBlock.name,
+          input: toolUseBlock.input,
+          status: 'pending',
+          startTime: new Date().toISOString(),
+        });
+      }
+    }
+
+    return executions;
+  }
+
+  /**
+   * バッファからtool_use_groupを含むUIMessageを作成
+   */
+  private createToolUseGroupMessage(
+    messages: SDKAssistantMessage[],
+    toolExecutions: ToolExecution[]
+  ): UIMessage {
+    const firstMessage = messages[0];
+    const blocks: AssistantMessageBlock[] = [];
+
+    // 単一のtool_useの場合は個別に、複数の場合はグループ化
+    if (toolExecutions.length === 1) {
+      blocks.push({
+        type: 'tool_use',
+        info: toolExecutions[0],
+      });
+    } else {
+      blocks.push({
+        type: 'tool_use_group',
+        executions: toolExecutions,
+      });
+    }
+
+    const metadata: UIMessageMetadata = {
+      sdkMessageUuids: messages.map((m) => m.uuid).filter((uuid): uuid is string => !!uuid),
+      role: 'assistant',
+      model: firstMessage.message?.model,
+      stopReason: firstMessage.message?.stop_reason,
+    };
+
+    // usage情報は最初のメッセージから取得
+    if (firstMessage.message?.usage) {
+      metadata.usage = {
+        inputTokens: firstMessage.message.usage.input_tokens || 0,
+        outputTokens: firstMessage.message.usage.output_tokens || 0,
+      };
+    }
+
+    return {
+      id: uuidv4(),
+      timestamp: firstMessage.created_at || new Date().toISOString(),
+      type: 'assistant_message',
+      content: {
+        type: 'assistant_message',
+        blocks,
+      },
+      metadata,
+    };
+  }
+
+  /**
    * Raw messages配列からUIMessages配列に変換
    */
   convert(rawMessages: unknown[]): UIMessage[] {
     const uiMessages: UIMessage[] = [];
     const toolExecutionMap = new Map<string, ToolExecution>();
+
+    // 連続するtool_useのみのassistantメッセージをバッファリング
+    let assistantToolUseBuffer: {
+      messages: SDKAssistantMessage[];
+      toolExecutions: ToolExecution[];
+    } | null = null;
+
+    const flushAssistantToolUseBuffer = () => {
+      if (assistantToolUseBuffer && assistantToolUseBuffer.toolExecutions.length > 0) {
+        // バッファのtool_useをグループ化して1つのUIMessageに変換
+        const groupMessage = this.createToolUseGroupMessage(
+          assistantToolUseBuffer.messages,
+          assistantToolUseBuffer.toolExecutions
+        );
+        uiMessages.push(groupMessage);
+
+        // toolExecutionMapにも登録（後でtool_resultと紐付けるため）
+        for (const exec of assistantToolUseBuffer.toolExecutions) {
+          toolExecutionMap.set(exec.id, exec);
+        }
+
+        assistantToolUseBuffer = null;
+      }
+    };
 
     for (const rawMsg of rawMessages) {
       const msg = rawMsg as SDKMessage;
@@ -102,6 +216,7 @@ export class UIMessageConverter {
 
       switch (msg.type) {
         case 'prompt': {
+          flushAssistantToolUseBuffer();
           const promptMsg = msg as SDKPromptMessage;
           uiMessages.push(this.convertPromptMessage(promptMsg));
           break;
@@ -109,32 +224,50 @@ export class UIMessageConverter {
 
         case 'user': {
           const userMsg = msg as SDKUserMessage;
-          // Skip tool_result messages (they will be processed separately)
+
           if (this.isToolResultMessage(userMsg)) {
+            // tool_resultの場合はバッファをフラッシュせずに処理
+            // （連続するtool_useの流れを継続）
             this.processToolResult(userMsg, toolExecutionMap, uiMessages);
           } else {
+            // 通常のuserメッセージ（text）の場合のみフラッシュ
+            flushAssistantToolUseBuffer();
             uiMessages.push(this.convertUserMessage(userMsg));
           }
           break;
         }
 
-        case 'assistant':
-          const assistantMsg = this.convertAssistantMessage(
-            msg as SDKAssistantMessage,
-            toolExecutionMap
-          );
-          if (assistantMsg) {
-            uiMessages.push(assistantMsg);
+        case 'assistant': {
+          const assistantMsg = msg as SDKAssistantMessage;
+
+          // tool_useのみのメッセージの場合はバッファに追加
+          if (this.isToolUseOnlyMessage(assistantMsg)) {
+            if (!assistantToolUseBuffer) {
+              assistantToolUseBuffer = { messages: [], toolExecutions: [] };
+            }
+            assistantToolUseBuffer.messages.push(assistantMsg);
+            const executions = this.extractToolExecutions(assistantMsg);
+            assistantToolUseBuffer.toolExecutions.push(...executions);
+          } else {
+            // thinking/textを含むメッセージの場合はバッファをフラッシュしてから処理
+            flushAssistantToolUseBuffer();
+            const convertedMsg = this.convertAssistantMessage(assistantMsg, toolExecutionMap);
+            if (convertedMsg) {
+              uiMessages.push(convertedMsg);
+            }
           }
           break;
+        }
 
         case 'system':
+          flushAssistantToolUseBuffer();
           if ((msg as SDKSystemMessage).subtype === 'init') {
             uiMessages.push(this.convertSystemInit(msg as SDKSystemMessage));
           }
           break;
 
         case 'result':
+          flushAssistantToolUseBuffer();
           const resultMsg = this.convertResultMessage(msg as SDKResultMessage);
           if (resultMsg) {
             uiMessages.push(resultMsg);
@@ -142,6 +275,9 @@ export class UIMessageConverter {
           break;
       }
     }
+
+    // 最後にバッファが残っていたらフラッシュ
+    flushAssistantToolUseBuffer();
 
     return uiMessages;
   }
@@ -188,10 +324,16 @@ export class UIMessageConverter {
         for (let i = uiMessages.length - 1; i >= 0; i--) {
           const uiMsg = uiMessages[i];
           if (uiMsg.type === 'assistant_message' && uiMsg.content.type === 'assistant_message') {
-            // Check if this message contains the target tool_use
-            const hasTargetToolUse = uiMsg.content.blocks.some(
-              (block) => block.type === 'tool_use' && block.info.id === toolUseId
-            );
+            // Check if this message contains the target tool_use (in tool_use or tool_use_group)
+            const hasTargetToolUse = uiMsg.content.blocks.some((block) => {
+              if (block.type === 'tool_use' && block.info.id === toolUseId) {
+                return true;
+              }
+              if (block.type === 'tool_use_group') {
+                return block.executions.some((exec) => exec.id === toolUseId);
+              }
+              return false;
+            });
 
             if (hasTargetToolUse) {
               const updatedBlocks = uiMsg.content.blocks.map((block) => {
@@ -205,6 +347,23 @@ export class UIMessageConverter {
                       error: isError ? resultContent : undefined,
                       endTime: new Date().toISOString(),
                     },
+                  };
+                }
+                if (block.type === 'tool_use_group') {
+                  return {
+                    ...block,
+                    executions: block.executions.map((exec) => {
+                      if (exec.id === toolUseId) {
+                        return {
+                          ...exec,
+                          result: resultContent,
+                          status: isError ? ('error' as const) : ('success' as const),
+                          error: isError ? resultContent : undefined,
+                          endTime: new Date().toISOString(),
+                        };
+                      }
+                      return exec;
+                    }),
                   };
                 }
                 return block;
@@ -291,9 +450,31 @@ export class UIMessageConverter {
       return null;
     }
 
-    // content配列を順番に処理
+    // content配列を順番に処理し、連続するtool_useをグループ化
+    let toolUseBuffer: ToolExecution[] = [];
+
+    const flushToolUseBuffer = () => {
+      if (toolUseBuffer.length > 0) {
+        if (toolUseBuffer.length === 1) {
+          // 単一のtool_useはそのまま追加
+          blocks.push({
+            type: 'tool_use',
+            info: toolUseBuffer[0],
+          });
+        } else {
+          // 複数のtool_useはtool_use_groupとして追加
+          blocks.push({
+            type: 'tool_use_group',
+            executions: toolUseBuffer,
+          });
+        }
+        toolUseBuffer = [];
+      }
+    };
+
     for (const block of content) {
       if (block.type === 'thinking') {
+        flushToolUseBuffer(); // tool_useバッファをフラッシュ
         const thinkingBlock = block as SDKThinkingBlock;
         blocks.push({
           type: 'thinking',
@@ -301,12 +482,14 @@ export class UIMessageConverter {
           isRedacted: false,
         });
       } else if (block.type === 'redacted_thinking') {
+        flushToolUseBuffer(); // tool_useバッファをフラッシュ
         blocks.push({
           type: 'thinking',
           content: '[Redacted for safety]',
           isRedacted: true,
         });
       } else if (block.type === 'text') {
+        flushToolUseBuffer(); // tool_useバッファをフラッシュ
         const textBlock = block as SDKTextBlock;
         blocks.push({
           type: 'text',
@@ -325,12 +508,13 @@ export class UIMessageConverter {
         // tool_use_idでマップに保存（後でtool_resultと紐付け）
         toolExecutionMap.set(toolUseBlock.id, toolExecution);
 
-        blocks.push({
-          type: 'tool_use',
-          info: toolExecution,
-        });
+        // バッファに追加（連続するtool_useを集める）
+        toolUseBuffer.push(toolExecution);
       }
     }
+
+    // 残りのtool_useをフラッシュ
+    flushToolUseBuffer();
 
     if (blocks.length === 0) {
       return null;

--- a/src/lib/ui-message-converter.ts
+++ b/src/lib/ui-message-converter.ts
@@ -129,46 +129,36 @@ export class UIMessageConverter {
   }
 
   /**
-   * バッファからtool_use_groupを含むUIMessageを作成
+   * 単一のtool_useメッセージからtool_use_groupを含むUIMessageを作成
    */
-  private createToolUseGroupMessage(
-    messages: SDKAssistantMessage[],
-    toolExecutions: ToolExecution[]
-  ): UIMessage {
-    const firstMessage = messages[0];
-    const blocks: AssistantMessageBlock[] = [];
+  private createToolUseGroupMessage(toolUseMsg: SDKAssistantMessage): UIMessage {
+    const executions = this.extractToolExecutions(toolUseMsg);
 
-    // 単一のtool_useの場合は個別に、複数の場合はグループ化
-    if (toolExecutions.length === 1) {
-      blocks.push({
-        type: 'tool_use',
-        info: toolExecutions[0],
-      });
-    } else {
-      blocks.push({
+    // 常にtool_use_groupとして作成（単一でもexecutions配列）
+    const blocks: AssistantMessageBlock[] = [
+      {
         type: 'tool_use_group',
-        executions: toolExecutions,
-      });
-    }
+        executions: executions,
+      },
+    ];
 
     const metadata: UIMessageMetadata = {
-      sdkMessageUuids: messages.map((m) => m.uuid).filter((uuid): uuid is string => !!uuid),
+      sdkMessageUuids: toolUseMsg.uuid ? [toolUseMsg.uuid] : [],
       role: 'assistant',
-      model: firstMessage.message?.model,
-      stopReason: firstMessage.message?.stop_reason,
+      model: toolUseMsg.message?.model,
+      stopReason: toolUseMsg.message?.stop_reason,
     };
 
-    // usage情報は最初のメッセージから取得
-    if (firstMessage.message?.usage) {
+    if (toolUseMsg.message?.usage) {
       metadata.usage = {
-        inputTokens: firstMessage.message.usage.input_tokens || 0,
-        outputTokens: firstMessage.message.usage.output_tokens || 0,
+        inputTokens: toolUseMsg.message.usage.input_tokens || 0,
+        outputTokens: toolUseMsg.message.usage.output_tokens || 0,
       };
     }
 
     return {
       id: uuidv4(),
-      timestamp: firstMessage.created_at || new Date().toISOString(),
+      timestamp: toolUseMsg.created_at || new Date().toISOString(),
       type: 'assistant_message',
       content: {
         type: 'assistant_message',
@@ -179,126 +169,43 @@ export class UIMessageConverter {
   }
 
   /**
-   * Raw messages配列からUIMessages配列に変換
+   * UIMessageがtool_use関連メッセージかチェック
    */
-  convert(rawMessages: unknown[]): UIMessage[] {
-    const uiMessages: UIMessage[] = [];
-    const toolExecutionMap = new Map<string, ToolExecution>();
-
-    // 連続するtool_useのみのassistantメッセージをバッファリング
-    let assistantToolUseBuffer: {
-      messages: SDKAssistantMessage[];
-      toolExecutions: ToolExecution[];
-    } | null = null;
-
-    const flushAssistantToolUseBuffer = () => {
-      if (assistantToolUseBuffer && assistantToolUseBuffer.toolExecutions.length > 0) {
-        // バッファのtool_useをグループ化して1つのUIMessageに変換
-        const groupMessage = this.createToolUseGroupMessage(
-          assistantToolUseBuffer.messages,
-          assistantToolUseBuffer.toolExecutions
-        );
-        uiMessages.push(groupMessage);
-
-        // toolExecutionMapにも登録（後でtool_resultと紐付けるため）
-        for (const exec of assistantToolUseBuffer.toolExecutions) {
-          toolExecutionMap.set(exec.id, exec);
-        }
-
-        assistantToolUseBuffer = null;
-      }
-    };
-
-    for (const rawMsg of rawMessages) {
-      const msg = rawMsg as SDKMessage;
-
-      if (!msg || !msg.type) continue;
-
-      switch (msg.type) {
-        case 'prompt': {
-          flushAssistantToolUseBuffer();
-          const promptMsg = msg as SDKPromptMessage;
-          uiMessages.push(this.convertPromptMessage(promptMsg));
-          break;
-        }
-
-        case 'user': {
-          const userMsg = msg as SDKUserMessage;
-
-          if (this.isToolResultMessage(userMsg)) {
-            // tool_resultの場合はバッファをフラッシュせずに処理
-            // （連続するtool_useの流れを継続）
-            this.processToolResult(userMsg, toolExecutionMap, uiMessages);
-          } else {
-            // 通常のuserメッセージ（text）の場合のみフラッシュ
-            flushAssistantToolUseBuffer();
-            uiMessages.push(this.convertUserMessage(userMsg));
-          }
-          break;
-        }
-
-        case 'assistant': {
-          const assistantMsg = msg as SDKAssistantMessage;
-
-          // tool_useのみのメッセージの場合はバッファに追加
-          if (this.isToolUseOnlyMessage(assistantMsg)) {
-            if (!assistantToolUseBuffer) {
-              assistantToolUseBuffer = { messages: [], toolExecutions: [] };
-            }
-            assistantToolUseBuffer.messages.push(assistantMsg);
-            const executions = this.extractToolExecutions(assistantMsg);
-            assistantToolUseBuffer.toolExecutions.push(...executions);
-          } else {
-            // thinking/textを含むメッセージの場合はバッファをフラッシュしてから処理
-            flushAssistantToolUseBuffer();
-            const convertedMsg = this.convertAssistantMessage(assistantMsg, toolExecutionMap);
-            if (convertedMsg) {
-              uiMessages.push(convertedMsg);
-            }
-          }
-          break;
-        }
-
-        case 'system':
-          flushAssistantToolUseBuffer();
-          if ((msg as SDKSystemMessage).subtype === 'init') {
-            uiMessages.push(this.convertSystemInit(msg as SDKSystemMessage));
-          }
-          break;
-
-        case 'result':
-          flushAssistantToolUseBuffer();
-          const resultMsg = this.convertResultMessage(msg as SDKResultMessage);
-          if (resultMsg) {
-            uiMessages.push(resultMsg);
-          }
-          break;
-      }
-    }
-
-    // 最後にバッファが残っていたらフラッシュ
-    flushAssistantToolUseBuffer();
-
-    return uiMessages;
-  }
-
-  private isToolResultMessage(msg: SDKUserMessage): boolean {
-    if (!msg.message || !Array.isArray(msg.message.content)) {
+  private isToolUseGroupMessage(msg: UIMessage): boolean {
+    if (msg.type !== 'assistant_message' || msg.content.type !== 'assistant_message') {
       return false;
     }
-    return msg.message.content.some((block) => block.type === 'tool_result');
+
+    return msg.content.blocks.some((block) => block.type === 'tool_use_group');
   }
 
-  private processToolResult(
-    msg: SDKUserMessage,
-    toolExecutionMap: Map<string, ToolExecution>,
-    uiMessages: UIMessage[]
-  ): void {
-    if (!msg.message || !Array.isArray(msg.message.content)) {
+  /**
+   * 既存のtool_use_groupに新しいtool_useを追加
+   */
+  private addToolToGroup(lastMsg: UIMessage, toolUseMsg: SDKAssistantMessage): void {
+    if (lastMsg.type !== 'assistant_message' || lastMsg.content.type !== 'assistant_message') {
       return;
     }
 
-    for (const block of msg.message.content) {
+    const executions = this.extractToolExecutions(toolUseMsg);
+
+    for (const block of lastMsg.content.blocks) {
+      if (block.type === 'tool_use_group') {
+        block.executions.push(...executions);
+        return;
+      }
+    }
+  }
+
+  /**
+   * tool_resultでtool_useのstatusを更新
+   */
+  private updateToolStatus(uiMessages: UIMessage[], toolResultMsg: SDKUserMessage): void {
+    if (!toolResultMsg.message || !Array.isArray(toolResultMsg.message.content)) {
+      return;
+    }
+
+    for (const block of toolResultMsg.message.content) {
       if (block.type === 'tool_result') {
         const toolResultBlock = block as {
           type: 'tool_result';
@@ -320,68 +227,106 @@ export class UIMessageConverter {
             .join('\n');
         }
 
-        // Find and update the corresponding tool_use in uiMessages
+        // uiMessagesを逆順に走査して対応するtool_useを探す
         for (let i = uiMessages.length - 1; i >= 0; i--) {
           const uiMsg = uiMessages[i];
           if (uiMsg.type === 'assistant_message' && uiMsg.content.type === 'assistant_message') {
-            // Check if this message contains the target tool_use (in tool_use or tool_use_group)
-            const hasTargetToolUse = uiMsg.content.blocks.some((block) => {
-              if (block.type === 'tool_use' && block.info.id === toolUseId) {
-                return true;
-              }
+            for (const block of uiMsg.content.blocks) {
               if (block.type === 'tool_use_group') {
-                return block.executions.some((exec) => exec.id === toolUseId);
+                const exec = block.executions.find((e) => e.id === toolUseId);
+                if (exec) {
+                  exec.status = isError ? 'error' : 'success';
+                  exec.result = resultContent;
+                  exec.error = isError ? resultContent : undefined;
+                  exec.endTime = new Date().toISOString();
+                  return;
+                }
               }
-              return false;
-            });
-
-            if (hasTargetToolUse) {
-              const updatedBlocks = uiMsg.content.blocks.map((block) => {
-                if (block.type === 'tool_use' && block.info.id === toolUseId) {
-                  return {
-                    ...block,
-                    info: {
-                      ...block.info,
-                      result: resultContent,
-                      status: isError ? ('error' as const) : ('success' as const),
-                      error: isError ? resultContent : undefined,
-                      endTime: new Date().toISOString(),
-                    },
-                  };
-                }
-                if (block.type === 'tool_use_group') {
-                  return {
-                    ...block,
-                    executions: block.executions.map((exec) => {
-                      if (exec.id === toolUseId) {
-                        return {
-                          ...exec,
-                          result: resultContent,
-                          status: isError ? ('error' as const) : ('success' as const),
-                          error: isError ? resultContent : undefined,
-                          endTime: new Date().toISOString(),
-                        };
-                      }
-                      return exec;
-                    }),
-                  };
-                }
-                return block;
-              });
-
-              uiMessages[i] = {
-                ...uiMsg,
-                content: {
-                  ...uiMsg.content,
-                  blocks: updatedBlocks,
-                },
-              };
-              break;
             }
           }
         }
       }
     }
+  }
+
+  /**
+   * Raw messages配列からUIMessages配列に変換
+   */
+  convert(rawMessages: unknown[]): UIMessage[] {
+    const uiMessages: UIMessage[] = [];
+
+    for (const rawMsg of rawMessages) {
+      const msg = rawMsg as SDKMessage;
+
+      if (!msg || !msg.type) continue;
+
+      switch (msg.type) {
+        case 'prompt': {
+          const promptMsg = msg as SDKPromptMessage;
+          uiMessages.push(this.convertPromptMessage(promptMsg));
+          break;
+        }
+
+        case 'user': {
+          const userMsg = msg as SDKUserMessage;
+
+          if (this.isToolResultMessage(userMsg)) {
+            // tool_resultの場合、uiMessagesを走査してstatusを更新
+            this.updateToolStatus(uiMessages, userMsg);
+          } else {
+            // 通常のuserメッセージ
+            uiMessages.push(this.convertUserMessage(userMsg));
+          }
+          break;
+        }
+
+        case 'assistant': {
+          const assistantMsg = msg as SDKAssistantMessage;
+
+          if (this.isToolUseOnlyMessage(assistantMsg)) {
+            // tool_useのみのメッセージ
+            const lastMsg = uiMessages[uiMessages.length - 1];
+
+            if (lastMsg && this.isToolUseGroupMessage(lastMsg)) {
+              // 既存のtool_use_groupに追加
+              this.addToolToGroup(lastMsg, assistantMsg);
+            } else {
+              // 新しいtool_use_groupを作成
+              uiMessages.push(this.createToolUseGroupMessage(assistantMsg));
+            }
+          } else {
+            // thinking/textを含むメッセージ
+            const convertedMsg = this.convertAssistantMessage(assistantMsg);
+            if (convertedMsg) {
+              uiMessages.push(convertedMsg);
+            }
+          }
+          break;
+        }
+
+        case 'system':
+          if ((msg as SDKSystemMessage).subtype === 'init') {
+            uiMessages.push(this.convertSystemInit(msg as SDKSystemMessage));
+          }
+          break;
+
+        case 'result':
+          const resultMsg = this.convertResultMessage(msg as SDKResultMessage);
+          if (resultMsg) {
+            uiMessages.push(resultMsg);
+          }
+          break;
+      }
+    }
+
+    return uiMessages;
+  }
+
+  private isToolResultMessage(msg: SDKUserMessage): boolean {
+    if (!msg.message || !Array.isArray(msg.message.content)) {
+      return false;
+    }
+    return msg.message.content.some((block) => block.type === 'tool_result');
   }
 
   private convertPromptMessage(msg: SDKPromptMessage): UIMessage {
@@ -434,10 +379,7 @@ export class UIMessageConverter {
     };
   }
 
-  private convertAssistantMessage(
-    msg: SDKAssistantMessage,
-    toolExecutionMap: Map<string, ToolExecution>
-  ): UIMessage | null {
+  private convertAssistantMessage(msg: SDKAssistantMessage): UIMessage | null {
     const blocks: AssistantMessageBlock[] = [];
 
     if (!msg.message || !msg.message.content) {
@@ -504,9 +446,6 @@ export class UIMessageConverter {
           status: 'pending',
           startTime: new Date().toISOString(),
         };
-
-        // tool_use_idでマップに保存（後でtool_resultと紐付け）
-        toolExecutionMap.set(toolUseBlock.id, toolExecution);
 
         // バッファに追加（連続するtool_useを集める）
         toolUseBuffer.push(toolExecution);
@@ -603,47 +542,4 @@ export class UIMessageConverter {
       };
     }
   }
-}
-
-/**
- * Tool resultを使ってToolExecutionのstatusを更新する
- */
-export function updateToolExecutionStatus(
-  uiMessages: UIMessage[],
-  toolUseId: string,
-  result: string,
-  isError: boolean
-): UIMessage[] {
-  return uiMessages.map((msg) => {
-    if (msg.type === 'assistant_message' && msg.content.type === 'assistant_message') {
-      const blocks = msg.content.blocks.map((block) => {
-        if (block.type === 'tool_use' && block.info.id === toolUseId) {
-          return {
-            ...block,
-            info: {
-              ...block.info,
-              result,
-              status: isError ? ('error' as const) : ('success' as const),
-              error: isError ? result : undefined,
-              endTime: new Date().toISOString(),
-            },
-          };
-        }
-        return block;
-      });
-
-      return {
-        ...msg,
-        content: {
-          ...msg.content,
-          blocks,
-        },
-        metadata: {
-          ...msg.metadata,
-          updatedAt: new Date().toISOString(),
-        },
-      };
-    }
-    return msg;
-  });
 }


### PR DESCRIPTION
連続するtool_useメッセージを1つにまとめてアコーディオン形式で表示する機能を実装。

## 変更内容

### 型定義 (src/lib/types.ts)
- AssistantMessageBlockにtool_use_group型を追加
- 複数のToolExecutionをグループ化して扱えるように拡張

### メッセージ変換ロジック (src/lib/ui-message-converter.ts)
- 複数のassistantメッセージをまたいで連続するtool_useをバッファリング
- tool_resultメッセージではバッファをフラッシュせず、連続性を維持
- 以下のタイミングでバッファをフラッシュ:
  - user[text]: 実際のユーザー入力
  - assistant[text/thinking]: Claudeの説明テキスト
  - system/result: システムメッセージ
- 2つ以上のtool_useが連続する場合はtool_use_groupとして1つにまとめる
- 単一のtool_useは従来通り個別に表示

### UI表示 (src/components/ExecutionLogsChat.tsx)
- tool_use_groupブロックの表示処理を追加
- 2段階アコーディオン構造:
  - レベル1: "Tool Uses (N)" でグループ全体を展開/折りたたみ
  - レベル2: 個別ツールの詳細を展開/折りたたみ
- 各ツールのinput/result、ステータスアイコンを表示