### PR TITLE
fix: change log scroll behavior from smooth to instant

### DIFF
--- a/src/components/ExecutionLogsChat.tsx
+++ b/src/components/ExecutionLogsChat.tsx
@@ -72,8 +72,8 @@ export function ExecutionLogsChat({ rawMessages, tabId }: ExecutionLogsChatProps
       logsEndRef.current?.scrollIntoView({ behavior: 'instant' as ScrollBehavior });
       // Note: setIsAtBottomはスクロールイベントで自動的に更新される
     } else if (isAtBottom) {
-      // 最下部にいる状態で新規メッセージ: スムーズスクロール
-      logsEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+      // 最下部にいる状態で新規メッセージ: 即座にスクロール
+      logsEndRef.current?.scrollIntoView({ behavior: 'instant' as ScrollBehavior });
     }
     // 最下部以外にいる場合: スクロールしない
   }, [uiMessages, tabId, isAtBottom]);


### PR DESCRIPTION
Long logs were taking too much time to scroll with smooth behavior. Changed to instant scroll for immediate display of the bottom.