### PR TITLE
fix: display user message count instead of tab count in task cards

### DIFF
--- a/src/app/api/tabs/[tab_id]/message/route.ts
+++ b/src/app/api/tabs/[tab_id]/message/route.ts
@@ -80,9 +80,12 @@ export async function POST(request: NextRequest, { params }: Params) {
 
     // SSE経由でブロードキャスト（マージ済みメッセージ）
     const messages = await tabRepo.getMergedMessages(tab_id);
+    const sessionData = await tabRepo.getSessionData(tab_id);
+    const userPromptCount = sessionData?.userPrompts?.length ?? 0;
     sseManager.broadcast('tab:messages:updated', {
       tab_id,
       messages,
+      userPromptCount,
     });
 
     // Execute Claude in background
@@ -100,9 +103,12 @@ export async function POST(request: NextRequest, { params }: Params) {
 
         // SSE broadcast (tab messages updated)
         const messages = await tabRepo.getMergedMessages(tab_id);
+        const sessionData = await tabRepo.getSessionData(tab_id);
+        const userPromptCount = sessionData?.userPrompts?.length ?? 0;
         sseManager.broadcast('tab:messages:updated', {
           tab_id,
           messages,
+          userPromptCount,
         });
       },
       onStatusChange: async (status) => {

--- a/src/app/api/tabs/[tab_id]/messages/route.ts
+++ b/src/app/api/tabs/[tab_id]/messages/route.ts
@@ -13,7 +13,11 @@ export async function GET(request: NextRequest, { params }: Params) {
     // Repository層でマージ済みメッセージを取得
     const messages = await tabRepo.getMergedMessages(tab_id);
 
-    return NextResponse.json({ data: { messages } });
+    // ユーザーメッセージ数を取得
+    const sessionData = await tabRepo.getSessionData(tab_id);
+    const userPromptCount = sessionData?.userPrompts?.length ?? 0;
+
+    return NextResponse.json({ data: { messages, userPromptCount } });
   } catch (error) {
     console.error('GET /api/tabs/[tab_id]/messages error:', error);
     return NextResponse.json({ error: 'Failed to fetch messages' }, { status: 500 });

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import * as taskRepo from '@/lib/task-repository';
+import * as tabRepo from '@/lib/tab-repository';
 import * as worktreeManager from '@/lib/worktree-manager';
 import { sseManager } from '@/lib/sse-manager';
 
@@ -17,7 +18,23 @@ export async function GET(request: NextRequest, { params }: Params) {
       return NextResponse.json({ error: 'Task not found' }, { status: 404 });
     }
 
-    return NextResponse.json({ data: { task } });
+    // タブにuserPromptCountを追加
+    const tabsWithCounts = await Promise.all(
+      task.tabs.map(async (tab) => {
+        const sessionData = await tabRepo.getSessionData(tab.tab_id);
+        return {
+          ...tab,
+          userPromptCount: sessionData?.userPrompts?.length ?? 0,
+        };
+      })
+    );
+
+    const taskWithCounts = {
+      ...task,
+      tabs: tabsWithCounts,
+    };
+
+    return NextResponse.json({ data: { task: taskWithCounts } });
   } catch (error) {
     console.error('GET /api/tasks/[id] error:', error);
     return NextResponse.json({ error: 'Failed to fetch task' }, { status: 500 });

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import * as taskRepo from '@/lib/task-repository';
+import * as tabRepo from '@/lib/tab-repository';
 import * as worktreeManager from '@/lib/worktree-manager';
 import type { Task } from '@/lib/types';
 import { sseManager } from '@/lib/sse-manager';
@@ -20,7 +21,26 @@ export async function GET(request: NextRequest) {
       includeDeleted,
     });
 
-    return NextResponse.json({ data: { tasks } });
+    // 各タスクのタブにuserPromptCountを追加
+    const tasksWithCounts = await Promise.all(
+      tasks.map(async (task) => {
+        const tabsWithCounts = await Promise.all(
+          task.tabs.map(async (tab) => {
+            const sessionData = await tabRepo.getSessionData(tab.tab_id);
+            return {
+              ...tab,
+              userPromptCount: sessionData?.userPrompts?.length ?? 0,
+            };
+          })
+        );
+        return {
+          ...task,
+          tabs: tabsWithCounts,
+        };
+      })
+    );
+
+    return NextResponse.json({ data: { tasks: tasksWithCounts } });
   } catch (error) {
     console.error('GET /api/tasks error:', error);
     return NextResponse.json({ error: 'Failed to fetch tasks' }, { status: 500 });

--- a/src/app/tasks/[id]/page.tsx
+++ b/src/app/tasks/[id]/page.tsx
@@ -75,7 +75,7 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
         const loadedTask = taskData.data.task;
         setTask(loadedTask);
 
-        // タスクからタブを取得
+        // タスクからタブを取得（既にuserPromptCountを含む）
         let loadedTabs = loadedTask.tabs || [];
 
         // タブが0個の場合、自動的に1個作成
@@ -99,7 +99,6 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
             const response = await fetch(`/api/tabs/${tab.tab_id}/messages`);
             if (response.ok) {
               const data = await response.json();
-              // APIは'rawMessages'ではなく'messages'を返す
               return { tab_id: tab.tab_id, messages: data.data.messages };
             }
           } catch (error) {
@@ -180,13 +179,21 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
 
     // tab:messages:updated イベント
     const handleTabMessagesUpdated = (event: MessageEvent) => {
-      const { tab_id, messages } = JSON.parse(event.data) as {
+      const { tab_id, messages, userPromptCount } = JSON.parse(event.data) as {
         tab_id: string;
         messages: MergedMessage[];
+        userPromptCount?: number;
       };
 
       // Backend側でマージ・ソート済みなのでそのまま使用
       setTabMessages((prev) => ({ ...prev, [tab_id]: messages }));
+
+      // タブのuserPromptCountを更新
+      if (userPromptCount !== undefined) {
+        setTabs((prevTabs) =>
+          prevTabs.map((tab) => (tab.tab_id === tab_id ? { ...tab, userPromptCount } : tab))
+        );
+      }
     };
 
     // task:updated イベント

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -14,7 +14,7 @@ interface TaskCardProps {
 export function TaskCard({ task, isDragging, onTaskClick }: TaskCardProps) {
   const isClaudeRunning = task.claudeState === 'running';
   const tabs = task.tabs || [];
-  const totalTabs = tabs.length;
+  const totalUserMessages = tabs.reduce((sum, tab) => sum + (tab.userPromptCount ?? 0), 0);
 
   return (
     <div
@@ -68,10 +68,10 @@ export function TaskCard({ task, isDragging, onTaskClick }: TaskCardProps) {
           {/* 工数 */}
           {task.effort && <span className="font-medium">{task.effort}h</span>}
 
-          {/* タブ数 */}
-          {totalTabs > 0 && (
+          {/* ユーザーメッセージ数 */}
+          {totalUserMessages > 0 && (
             <div className="flex items-center gap-1">
-              <span>{totalTabs}</span>
+              <span>{totalUserMessages}</span>
               <MessageCircle className="w-3 h-3" />
             </div>
           )}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -28,6 +28,7 @@ export interface Tab {
   completedAt?: string;
   updatedAt: string;
   session_id?: string; // Claude Agent SDKのセッションID（初回プロンプト後に設定）
+  userPromptCount?: number; // ユーザーが送信したメッセージ数
 }
 
 // UserPrompt型（ユーザーが送信したプロンプト）


### PR DESCRIPTION
タスクカードに表示されるメッセージ数を、タブ数からユーザーが送信したメッセージ数（userPrompts配列の長さ）に変更しました。

### 変更内容

**型定義**
- Tab型にuserPromptCountフィールドを追加

**API修正**
- GET /api/tabs/[tab_id]/messages: userPromptCountを返すように修正
- POST /api/tabs/[tab_id]/message: SSEイベントでuserPromptCountを送信（2箇所）
- GET /api/tasks: 一覧取得時に各タブのuserPromptCountを取得
- GET /api/tasks/[id]: 詳細取得時に各タブのuserPromptCountを取得

**フロントエンド修正**
- TaskCard.tsx: タブ数の代わりにユーザーメッセージ数の合計を表示
- tasks/[id]/page.tsx: SSEイベントでuserPromptCountをリアルタイム更新

### テスト
- ✅ Prettier
- ✅ ESLint
- ✅ TypeScript型チェック
- ✅ API動作確認済み