### PR TITLE
fix: improve input/select focus and hover states for better accessibi…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,10 @@ npm run type-check
 
 エラーがある場合は修正し、再度実行する。
 
+## Serena (MCP) 使用時の注意
+
+- **Serenaはdockerで動いているため、プロジェクトのactivateは常に `.` を指定**
+
 ## 実装計画
 
 - **実装計画は、ホームディレクトリではなく、必ずプロジェクトディレクトリの `{project root directory}/.claude/plans/procedures.md` で管理**

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -149,27 +149,20 @@ body {
 
 /* Global smooth transitions for theme changes */
 * {
-  transition-property:
-    color, background-color, border-color, opacity, transform, outline, outline-color;
+  transition-property: color, background-color, border-color, opacity, transform;
   transition-duration: 200ms;
   transition-timing-function: ease-in-out;
 }
 
-/* Dark theme: Brighten all interactive elements on hover */
+/* Dark theme: Brighten buttons on hover */
 @media (prefers-color-scheme: dark) {
-  button:hover:not(:disabled),
-  input:hover:not(:focus):not(:disabled),
-  textarea:hover:not(:focus):not(:disabled),
-  select:hover:not(:focus):not(:disabled) {
+  button:hover:not(:disabled) {
     filter: brightness(1.2);
   }
 }
 
 :root[data-theme='dark'] {
-  button:hover:not(:disabled),
-  input:hover:not(:focus):not(:disabled),
-  textarea:hover:not(:focus):not(:disabled),
-  select:hover:not(:focus):not(:disabled) {
+  button:hover:not(:disabled) {
     filter: brightness(1.2);
   }
 }
@@ -180,48 +173,79 @@ body {
   scrollbar-color: var(--muted) var(--background);
 }
 
-/* Hover state for form inputs */
+/* Base form input styles */
+input,
+textarea,
+select {
+  transition-property: border-color, box-shadow;
+  transition-duration: 200ms;
+}
+
+/* Hover state - border color only */
 input:hover:not(:focus):not(:disabled),
 textarea:hover:not(:focus):not(:disabled),
 select:hover:not(:focus):not(:disabled) {
   border-color: var(--primary-light);
-  background-color: var(--hover-background);
 }
 
-/* Active state for form inputs */
-input:active:not(:disabled),
-textarea:active:not(:disabled),
-select:active:not(:disabled) {
-  border-color: var(--primary);
-  outline: 2px solid var(--primary);
-  outline-offset: 2px;
-}
-
-/* Override focus ring color for form inputs */
+/* Focus-visible state - ring only, no border color change */
 input:focus-visible,
 textarea:focus-visible,
 select:focus-visible {
-  outline: 2px solid var(--primary);
-  outline-offset: 2px;
-  border-color: var(--primary);
-  background-color: var(--card-background);
+  outline: none;
+  box-shadow:
+    0 0 0 2px var(--background),
+    0 0 0 4px var(--primary);
 }
 
-/* Error state focus ring color */
-/* Auto-detect error state by border-red-* class */
+/* Error state focus ring */
 input[class*='border-red']:focus-visible,
 textarea[class*='border-red']:focus-visible,
-select[class*='border-red']:focus-visible {
-  outline: 2px solid var(--error);
-  outline-offset: 2px;
-}
-
-/* Explicit error state with .input-error class */
+select[class*='border-red']:focus-visible,
 input.input-error:focus-visible,
 textarea.input-error:focus-visible,
 select.input-error:focus-visible {
-  outline: 2px solid var(--error);
-  outline-offset: 2px;
+  outline: none;
+  box-shadow:
+    0 0 0 2px var(--background),
+    0 0 0 4px var(--error);
+}
+
+/* Reusable form input class */
+.form-input {
+  border: 1px solid var(--border);
+  background-color: var(--card-background);
+  color: var(--foreground);
+  transition:
+    border-color 200ms,
+    box-shadow 200ms;
+}
+
+.form-input:hover:not(:focus):not(:disabled) {
+  border-color: var(--primary-light);
+}
+
+.form-input:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 2px var(--background),
+    0 0 0 4px var(--primary);
+}
+
+.form-input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.form-input-error {
+  border-color: var(--error);
+}
+
+.form-input-error:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 2px var(--background),
+    0 0 0 4px var(--error);
 }
 
 /* Custom select chevron styling */


### PR DESCRIPTION
…lity

- Remove brightness filter from input/select/textarea in dark mode (buttons only)
- Separate border and focus states clearly:
  - Hover: border-color change only (no background change)
  - Focus: box-shadow ring (ring-2 + ring-offset-2 equivalent)
- Add reusable .form-input and .form-input-error classes
- Use theme variables only (--border, --primary-light, --primary, --error)
- Improve keyboard navigation visibility