### PR TITLE
feat: improve prompt editor UX and reorganize UI components

### DIFF
--- a/src/app/tasks/[id]/page.tsx
+++ b/src/app/tasks/[id]/page.tsx
@@ -602,6 +602,7 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
                     <ExecutionLogsChat
                       rawMessages={tabMessages[activeTab.tab_id] || []}
                       tabId={activeTab.tab_id}
+                      tab={activeTab}
                     />
                   )}
                 </div>

--- a/src/components/ClaudePromptEditor.tsx
+++ b/src/components/ClaudePromptEditor.tsx
@@ -2,8 +2,8 @@
 
 import { Editor } from '@monaco-editor/react';
 import {
-  useState,
   useRef,
+  useState,
   useEffect,
   useCallback,
   forwardRef,
@@ -13,7 +13,6 @@ import {
 import type { editor } from 'monaco-editor';
 import type { Tab } from '@/lib/types';
 import { useTheme } from '@/contexts/ThemeContext';
-import { ClaudeState } from '@/components/ClaudeState';
 import { getClaudeStatus } from '@/lib/claude-status';
 import { Send, Square } from 'lucide-react';
 
@@ -29,136 +28,134 @@ export interface ClaudePromptEditorHandle {
   clearPrompt: () => void;
 }
 
-export const ClaudePromptEditor = memo(
-  forwardRef<ClaudePromptEditorHandle, ClaudePromptEditorProps>(
-    ({ tab, onExecute, onInterrupt }, ref) => {
-      const [isExecuting, setIsExecuting] = useState(false);
-      const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
-      const { effectiveTheme } = useTheme();
+const ClaudePromptEditorComponent = forwardRef<ClaudePromptEditorHandle, ClaudePromptEditorProps>(
+  ({ tab, onExecute, onInterrupt }, ref) => {
+    const [isExecuting, setIsExecuting] = useState(false);
+    const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
+    const { effectiveTheme } = useTheme();
 
-      // 親コンポーネントに公開するメソッド
-      useImperativeHandle(ref, () => ({
-        getCurrentPrompt: () => editorRef.current?.getValue() || '',
-        setPrompt: (value: string) => {
-          if (editorRef.current) {
-            editorRef.current.setValue(value);
-          }
-        },
-        clearPrompt: () => {
-          if (editorRef.current) {
-            editorRef.current.setValue('');
-          }
-        },
-      }));
-
-      const handleExecute = useCallback(async () => {
-        const prompt = editorRef.current?.getValue() || '';
-        if (!prompt.trim() || isExecuting) return;
-        try {
-          setIsExecuting(true);
-          await onExecute(tab.tab_id, prompt);
-          // Execute成功後、親コンポーネントがclearPromptを呼び出す
-        } catch (error) {
-          console.error('Failed to execute:', error);
-        } finally {
-          setIsExecuting(false);
+    // 親コンポーネントに公開するメソッド
+    useImperativeHandle(ref, () => ({
+      getCurrentPrompt: () => editorRef.current?.getValue() || '',
+      setPrompt: (value: string) => {
+        if (editorRef.current) {
+          editorRef.current.setValue(value);
         }
-      }, [isExecuting, onExecute, tab.tab_id]);
-
-      const handleInterrupt = useCallback(async () => {
-        try {
-          await onInterrupt(tab.tab_id);
-        } catch (error) {
-          console.error('Failed to interrupt:', error);
+      },
+      clearPrompt: () => {
+        if (editorRef.current) {
+          editorRef.current.setValue('');
         }
-      }, [onInterrupt, tab.tab_id]);
+      },
+    }));
 
-      // 常に最新のハンドラーを参照するためのref
-      const handleExecuteRef = useRef(handleExecute);
-      const handleInterruptRef = useRef(handleInterrupt);
+    const handleExecute = useCallback(async () => {
+      const prompt = editorRef.current?.getValue() || '';
+      if (!prompt.trim() || isExecuting) return;
+      try {
+        setIsExecuting(true);
+        await onExecute(tab.tab_id, prompt);
+      } catch (error) {
+        console.error('Failed to execute:', error);
+      } finally {
+        setIsExecuting(false);
+      }
+    }, [isExecuting, onExecute, tab.tab_id]);
 
-      useEffect(() => {
-        handleExecuteRef.current = handleExecute;
-      }, [handleExecute]);
+    const handleInterrupt = useCallback(async () => {
+      try {
+        await onInterrupt(tab.tab_id);
+      } catch (error) {
+        console.error('Failed to interrupt:', error);
+      }
+    }, [onInterrupt, tab.tab_id]);
 
-      useEffect(() => {
-        handleInterruptRef.current = handleInterrupt;
-      }, [handleInterrupt]);
+    // 常に最新のハンドラーを参照するためのref
+    const handleExecuteRef = useRef(handleExecute);
+    const handleInterruptRef = useRef(handleInterrupt);
 
-      const status = getClaudeStatus(tab);
-      const isRunning = status === 'running';
-      const canExecute = !isExecuting && !isRunning;
+    useEffect(() => {
+      handleExecuteRef.current = handleExecute;
+    }, [handleExecute]);
 
-      return (
-        <div className="flex flex-col h-full min-h-0">
-          <div className="flex items-center justify-between mb-2 flex-shrink-0 h-8">
-            <h3 className="text-sm font-semibold text-theme-fg">Prompt</h3>
-            <div className="flex items-center gap-2">
-              <ClaudeState status={status} />
+    useEffect(() => {
+      handleInterruptRef.current = handleInterrupt;
+    }, [handleInterrupt]);
 
-              {!isRunning && (
-                <button
-                  onClick={handleExecute}
-                  disabled={!canExecute}
-                  className="px-3 py-1 bg-primary text-white rounded text-sm hover:bg-primary-hover disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-primary cursor-pointer flex items-center gap-1"
-                >
-                  <Send className="w-3 h-3" />
-                  Send
-                </button>
-              )}
+    const status = getClaudeStatus(tab);
+    const isRunning = status === 'running';
+    const canExecute = !isExecuting && !isRunning;
 
-              {isRunning && (
-                <button
-                  onClick={handleInterrupt}
-                  className="px-3 py-1 bg-red-700 text-white rounded text-sm hover:bg-red-600 cursor-pointer flex items-center gap-1"
-                >
-                  <Square className="w-3 h-3" />
-                  Interrupt
-                </button>
-              )}
-            </div>
-          </div>
+    return (
+      <div className="flex flex-col h-full min-h-0">
+        <div className="flex items-center justify-between mb-2 flex-shrink-0 h-8">
+          <h3 className="text-sm font-semibold text-theme-fg">Prompt</h3>
+          <div className="flex items-center gap-2">
+            {!isRunning && (
+              <button
+                onClick={handleExecute}
+                disabled={!canExecute}
+                className="px-3 py-1 bg-primary text-white rounded text-sm hover:bg-primary-hover disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-primary cursor-pointer flex items-center gap-1"
+              >
+                <Send className="w-3 h-3" />
+                Send
+              </button>
+            )}
 
-          <div className="flex-1 min-h-0 border border-theme rounded overflow-hidden">
-            <Editor
-              height="100%"
-              defaultLanguage="markdown"
-              defaultValue=""
-              onMount={async (editor) => {
-                editorRef.current = editor;
-
-                // monaco-editorの型をインポート
-                const monaco = await import('monaco-editor');
-
-                // Cmd+Enter (Mac) / Ctrl+Enter (Windows/Linux) で Send
-                editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, () => {
-                  handleExecuteRef.current();
-                });
-
-                // Esc で Interrupt
-                editor.addCommand(monaco.KeyCode.Escape, () => {
-                  handleInterruptRef.current();
-                });
-              }}
-              options={{
-                minimap: { enabled: false },
-                lineNumbers: 'on',
-                wordWrap: 'on',
-                fontSize: 14,
-                scrollBeyondLastLine: false,
-                readOnly: isRunning,
-              }}
-              theme={effectiveTheme === 'dark' ? 'vs-dark' : 'vs-light'}
-            />
+            {isRunning && (
+              <button
+                onClick={handleInterrupt}
+                className="px-3 py-1 bg-red-700 text-white rounded text-sm hover:bg-red-600 cursor-pointer flex items-center gap-1"
+              >
+                <Square className="w-3 h-3" />
+                Interrupt
+              </button>
+            )}
           </div>
         </div>
-      );
-    }
-  ),
-  (prevProps, nextProps) => {
-    // タブIDと実行状態が変わらなければ再レンダリングしない
-    return (
-      prevProps.tab.tab_id === nextProps.tab.tab_id && prevProps.tab.status === nextProps.tab.status
+
+        <div className="flex-1 min-h-0 border border-theme rounded overflow-hidden">
+          <Editor
+            height="100%"
+            defaultLanguage="markdown"
+            defaultValue=""
+            onMount={async (editor) => {
+              editorRef.current = editor;
+
+              // monaco-editorの型をインポート
+              const monaco = await import('monaco-editor');
+
+              // Cmd+Enter (Mac) / Ctrl+Enter (Windows/Linux) で Send
+              editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, () => {
+                handleExecuteRef.current();
+              });
+
+              // Esc で Interrupt
+              editor.addCommand(monaco.KeyCode.Escape, () => {
+                handleInterruptRef.current();
+              });
+            }}
+            options={{
+              minimap: { enabled: false },
+              lineNumbers: 'on',
+              wordWrap: 'on',
+              fontSize: 14,
+              scrollBeyondLastLine: false,
+              readOnly: false,
+            }}
+            theme={effectiveTheme === 'dark' ? 'vs-dark' : 'vs-light'}
+          />
+        </div>
+      </div>
     );
   }
 );
+
+ClaudePromptEditorComponent.displayName = 'ClaudePromptEditor';
+
+export const ClaudePromptEditor = memo(ClaudePromptEditorComponent, (prevProps, nextProps) => {
+  // タブIDとステータスが変わらなければ再レンダリングしない
+  return (
+    prevProps.tab.tab_id === nextProps.tab.tab_id && prevProps.tab.status === nextProps.tab.status
+  );
+});

--- a/src/components/ExecutionLogsChat.tsx
+++ b/src/components/ExecutionLogsChat.tsx
@@ -13,9 +13,11 @@ import {
   Ban,
   CircleCheck,
 } from 'lucide-react';
-import type { UIMessage } from '@/lib/types';
+import type { UIMessage, Tab } from '@/lib/types';
 import { UIMessageConverter } from '@/lib/ui-message-converter';
 import { useTheme } from '@/contexts/ThemeContext';
+import { ClaudeState } from '@/components/ClaudeState';
+import { getClaudeStatus } from '@/lib/claude-status';
 
 // セッション完了状態を判定するヘルパー関数
 function isSessionCompleted(rawMessages?: unknown[]): boolean {
@@ -39,9 +41,10 @@ function isSessionCompleted(rawMessages?: unknown[]): boolean {
 interface ExecutionLogsChatProps {
   rawMessages?: unknown[]; // SDK messages
   tabId?: string; // タブ切り替え検知用
+  tab: Tab;
 }
 
-export function ExecutionLogsChat({ rawMessages, tabId }: ExecutionLogsChatProps) {
+export function ExecutionLogsChat({ rawMessages, tabId, tab }: ExecutionLogsChatProps) {
   const logsEndRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const [isAtBottom, setIsAtBottom] = useState(true);
@@ -49,6 +52,8 @@ export function ExecutionLogsChat({ rawMessages, tabId }: ExecutionLogsChatProps
 
   // セッション完了状態を判定
   const sessionCompleted = useMemo(() => isSessionCompleted(rawMessages), [rawMessages]);
+
+  const status = getClaudeStatus(tab);
 
   // rawMessagesをUIMessagesに変換
   const uiMessages = useMemo(() => {
@@ -92,6 +97,7 @@ export function ExecutionLogsChat({ rawMessages, tabId }: ExecutionLogsChatProps
     <div className="flex flex-col h-full min-h-0">
       <div className="flex items-center justify-between mb-2 flex-shrink-0 h-8">
         <h3 className="text-sm font-semibold text-theme-fg">Logs</h3>
+        <ClaudeState status={status} />
       </div>
 
       <div


### PR DESCRIPTION
- Enable prompt editing during Claude execution (readOnly: false)
- Keep Send/Interrupt buttons in Prompt header (maintain original position)
- Move Claude status indicator to Logs header (better visibility)
- Restore Cmd+Enter keyboard shortcut for sending prompts
- Restore Esc keyboard shortcut for interrupting execution

This change improves user experience by allowing users to prepare the next prompt while Claude is executing, while maintaining familiar button positions.