### PR TITLE
feat: highlight Rebase button when base branch has new commits

### DIFF
--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -29,9 +29,16 @@ export async function GET(request: NextRequest, { params }: Params) {
       })
     );
 
+    // worktreeが作成済みの場合、rebaseが必要かチェック
+    let needsRebase = false;
+    if (task.worktreeStatus === 'created') {
+      needsRebase = await worktreeManager.checkRebaseNeeded(task.owner, task.repo, task.branch);
+    }
+
     const taskWithCounts = {
       ...task,
       tabs: tabsWithCounts,
+      needsRebase,
     };
 
     return NextResponse.json({ data: { task: taskWithCounts } });

--- a/src/components/TaskActions.tsx
+++ b/src/components/TaskActions.tsx
@@ -126,8 +126,14 @@ export function TaskActions({ task, onDelete }: TaskActionsProps) {
         <button
           onClick={handleRebase}
           disabled={isRebaseDisabled}
-          title="Rebase to main"
-          className="w-auto px-4 py-2 bg-theme-card hover:bg-theme-hover text-theme-fg border border-theme rounded-lg flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+          title={
+            task.needsRebase ? 'Base branch has new commits - Rebase recommended' : 'Rebase to main'
+          }
+          className={`w-auto px-4 py-2 rounded-lg flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer ${
+            task.needsRebase
+              ? 'bg-primary-600 hover:bg-primary-hover text-white border-0'
+              : 'bg-theme-card hover:bg-theme-hover text-theme-fg border border-theme'
+          }`}
         >
           <GitMerge className="w-4 h-4" />
           Rebase
@@ -166,8 +172,16 @@ export function TaskActions({ task, onDelete }: TaskActionsProps) {
           <button
             onClick={handleRebase}
             disabled={isRebaseDisabled}
-            title="Rebase to main"
-            className="w-auto px-4 py-2 bg-theme-card hover:bg-theme-hover text-theme-fg border border-theme rounded-lg flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+            title={
+              task.needsRebase
+                ? 'Base branch has new commits - Rebase recommended'
+                : 'Rebase to main'
+            }
+            className={`w-auto px-4 py-2 rounded-lg flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer ${
+              task.needsRebase
+                ? 'bg-primary-600 hover:bg-primary-hover text-white border-0'
+                : 'bg-theme-card hover:bg-theme-hover text-theme-fg border border-theme'
+            }`}
           >
             <GitMerge className="w-4 h-4" />
             Rebase

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -17,6 +17,7 @@ export interface Task {
   createdAt: string;
   updatedAt: string;
   tabs: Tab[]; // タブ管理（Phase 1で追加）
+  needsRebase?: boolean; // base branchが進んでいてrebaseが必要か
 }
 
 // Tab型（タブとメッセージ履歴を分離）

--- a/src/lib/worktree-manager.ts
+++ b/src/lib/worktree-manager.ts
@@ -262,6 +262,45 @@ export async function listWorktrees(owner: string, repo: string): Promise<Worktr
   return worktrees;
 }
 
+// base branchが進んでいてrebaseが必要かチェック
+export async function checkRebaseNeeded(
+  owner: string,
+  repo: string,
+  branch: string,
+  baseBranch?: string
+): Promise<boolean> {
+  try {
+    const bareRepoPath = await ensureBareRepository(owner, repo);
+    const worktreePath = getWorktreePath(owner, repo, branch);
+
+    // worktreeが存在するか確認
+    try {
+      await fs.access(worktreePath);
+    } catch {
+      return false; // worktreeが存在しない場合はrebase不要
+    }
+
+    // リモートの最新状態を取得
+    const bareGit: SimpleGit = simpleGit(bareRepoPath);
+    await bareGit.fetch('origin', { '--prune': null });
+
+    // デフォルトブランチを取得
+    const effectiveBaseBranch = baseBranch || (await getDefaultBranch(owner, repo));
+    const targetRef = `origin/${effectiveBaseBranch}`;
+
+    // base branchの方が進んでいる場合（現在のブランチがbehind）
+    // HEAD..targetRef: base branchに存在して現在のブランチに無いコミット数
+    const git: SimpleGit = simpleGit(worktreePath);
+    const aheadResult = await git.raw(['rev-list', '--count', `HEAD..${targetRef}`]);
+    const aheadCount = parseInt(aheadResult.trim(), 10);
+
+    return aheadCount > 0; // base branchに新しいコミットがある場合はtrue
+  } catch (error) {
+    console.error('Failed to check rebase needed:', error);
+    return false; // エラー時はrebase不要として扱う
+  }
+}
+
 // worktreeをrebase
 export async function rebaseWorktree(
   owner: string,


### PR DESCRIPTION
タスク詳細でbase branchが進んでいる場合、Rebaseボタンをprimary colorでハイライト表示し、rebaseを推奨する機能を実装。

- worktree-manager: checkRebaseNeeded関数を追加してbase branchとの差分をチェック
- Task型: needsRebaseフィールドを追加
- タスク取得API: worktree作成済みの場合、rebase必要性を判定してレスポンスに含める
- TaskActions: needsRebaseがtrueの場合、Rebaseボタンをprimary colorで表示（Desktop/Mobile対応）