### PR TITLE
feat: SSE接続状態の可視化

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -413,6 +413,38 @@ select {
   background-color: rgba(17, 24, 39, 0.9);
 }
 
+/* Connection Status Indicator styles */
+.connection-status-indicator {
+  background-color: #ffffff !important;
+  border: 1px solid #e5e7eb !important;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) .connection-status-indicator {
+    background-color: #111827 !important;
+    border-color: #1f2937 !important;
+  }
+}
+
+:root[data-theme='dark'] .connection-status-indicator {
+  background-color: #111827 !important;
+  border-color: #1f2937 !important;
+}
+
+.connection-status-tooltip {
+  background-color: #111827;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) .connection-status-tooltip {
+    background-color: #374151;
+  }
+}
+
+:root[data-theme='dark'] .connection-status-tooltip {
+  background-color: #374151;
+}
+
 /* ReactMarkdown prose styles for Logs - ensure proper word wrapping and readability */
 .prose {
   /* Paragraph styling */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
 import { ThemeProvider } from '@/contexts/ThemeContext';
+import { ConnectionStatus } from '@/components/ConnectionStatus';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -26,7 +27,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <ThemeProvider>{children}</ThemeProvider>
+        <ThemeProvider>
+          {children}
+          <ConnectionStatus />
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/app/tasks/[id]/page.tsx
+++ b/src/app/tasks/[id]/page.tsx
@@ -40,7 +40,7 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
   const activeTab = tabs.find((t) => t.tab_id === activeTabId);
 
   // SSE統合
-  const { eventSource, isConnected } = useSSE();
+  const { eventSource, connectionState } = useSSE();
 
   // タブ切り替え時の処理（現在のプロンプトを保存）
   const handleTabChange = useCallback(
@@ -345,7 +345,7 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
   // タブのポーリング（running状態の場合のみ、SSE未接続時のフォールバック）
   useEffect(() => {
     // SSE接続済みの場合はポーリング不要
-    if (isConnected) return;
+    if (connectionState === 'connected') return;
     if (!activeTabId || !task) return;
 
     const pollTab = async () => {
@@ -385,7 +385,7 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
     return () => {
       clearInterval(intervalId);
     };
-  }, [isConnected, activeTabId, activeTab?.status, task]);
+  }, [connectionState, activeTabId, activeTab?.status, task]);
 
   // タスク更新
   const handleTaskUpdate = async (taskId: string, updates: Partial<Task>) => {
@@ -612,7 +612,7 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
         </div>
 
         {/* Quick Actions */}
-        <div className="p-4 border-t border-theme bg-theme-card flex-shrink-0">
+        <div className="px-4 py-4 pr-[72px] border-t border-theme bg-theme-card flex-shrink-0">
           <TaskActions task={task} onDelete={handleTaskDelete} />
         </div>
       </div>

--- a/src/components/ConnectionStatus.tsx
+++ b/src/components/ConnectionStatus.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { CheckCircle, RefreshCw, Unplug } from 'lucide-react';
+import { useSSE } from '@/hooks/useSSE';
+
+export function ConnectionStatus() {
+  const { connectionState } = useSSE();
+
+  // アイコンとスタイルの設定
+  const getStatusConfig = () => {
+    switch (connectionState) {
+      case 'connected':
+        return {
+          Icon: CheckCircle,
+          color: 'text-green-500',
+          label: '接続中',
+          spin: false,
+        };
+      case 'connecting':
+        return {
+          Icon: RefreshCw,
+          color: 'text-yellow-500',
+          label: '接続確立中',
+          spin: true,
+        };
+      case 'disconnected':
+        return {
+          Icon: Unplug,
+          color: 'text-red-500',
+          label: '切断',
+          spin: false,
+        };
+    }
+  };
+
+  const { Icon, color, label, spin } = getStatusConfig();
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50">
+      <div
+        className="connection-status-indicator group relative flex items-center justify-center w-10 h-10 rounded-lg shadow-lg cursor-pointer hover:shadow-xl transition-shadow"
+        title={label}
+      >
+        <Icon className={`w-5 h-5 ${color} ${spin ? 'animate-spin' : ''}`} aria-hidden="true" />
+
+        {/* Tooltip */}
+        <div className="absolute bottom-full right-0 mb-2 hidden group-hover:block">
+          <div className="connection-status-tooltip text-white text-xs rounded py-1 px-2 whitespace-nowrap">
+            {label}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useSSE.ts
+++ b/src/hooks/useSSE.ts
@@ -1,32 +1,89 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
+
+export type ConnectionState = 'connected' | 'connecting' | 'disconnected';
+
+const STALE_TIMEOUT = 60000; // 60秒
 
 export function useSSE() {
   const [eventSource, setEventSource] = useState<EventSource | null>(null);
-  const [isConnected, setIsConnected] = useState(false);
+  const [connectionState, setConnectionState] = useState<ConnectionState>('disconnected');
+  const [lastMessageAt, setLastMessageAt] = useState<number>(0);
+
+  // 接続状態を更新する関数
+  const updateConnectionState = useCallback((es: EventSource | null, lastMsg: number) => {
+    if (!es) {
+      setConnectionState('disconnected');
+      return;
+    }
+
+    const now = Date.now();
+    const isStale = now - lastMsg > STALE_TIMEOUT;
+
+    switch (es.readyState) {
+      case EventSource.CONNECTING:
+        setConnectionState('connecting');
+        break;
+      case EventSource.OPEN:
+        setConnectionState(isStale ? 'disconnected' : 'connected');
+        break;
+      case EventSource.CLOSED:
+        setConnectionState('disconnected');
+        break;
+    }
+  }, []);
 
   useEffect(() => {
     const es = new EventSource('/api/events');
-
-    es.addEventListener('connected', () => {
-      console.log('[SSE] Connected');
-      setIsConnected(true);
-    });
-
-    es.onerror = () => {
-      console.log('[SSE] Disconnected');
-      setIsConnected(false);
-      // ブラウザが自動的に再接続を試みる
-    };
-
-    // EventSourceをstateに設定
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setEventSource(es);
 
+    // 初期接続時刻を設定
+    setLastMessageAt(Date.now());
+
+    // メッセージ受信時刻を更新するハンドラー
+    const updateLastMessage = () => {
+      setLastMessageAt(Date.now());
+    };
+
+    // connected イベント
+    es.addEventListener('connected', () => {
+      console.log('[SSE] Connected');
+      updateLastMessage();
+    });
+
+    // すべてのイベントで最終受信時刻を更新
+    es.addEventListener('message', updateLastMessage);
+    es.addEventListener('task:created', updateLastMessage);
+    es.addEventListener('task:updated', updateLastMessage);
+    es.addEventListener('task:deleted', updateLastMessage);
+    es.addEventListener('tab:created', updateLastMessage);
+    es.addEventListener('tab:updated', updateLastMessage);
+    es.addEventListener('resync:hint', updateLastMessage);
+
+    // エラーハンドリング
+    es.onerror = () => {
+      console.log('[SSE] Error occurred');
+      // ブラウザが自動的に再接続を試みる
+    };
+
+    // 定期的に接続状態をチェック（5秒ごと）
+    const checkInterval = setInterval(() => {
+      updateConnectionState(es, Date.now());
+    }, 5000);
+
+    // クリーンアップ
     return () => {
       console.log('[SSE] Closing connection');
+      clearInterval(checkInterval);
       es.close();
     };
-  }, []);
+  }, [updateConnectionState]);
 
-  return { eventSource, isConnected };
+  // lastMessageAtが更新されたら接続状態を再評価
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    updateConnectionState(eventSource, lastMessageAt);
+  }, [eventSource, lastMessageAt, updateConnectionState]);
+
+  return { eventSource, connectionState };
 }


### PR DESCRIPTION
画面右下にSSE接続状態インジケーターを追加。

主な変更:
- useSSE hookを拡張し、3つの接続状態を提供（connected/connecting/disconnected）
- ConnectionStatusコンポーネントを実装（画面右下に固定表示）
- 接続状態に応じてアイコンとカラーを変更
  - connected: CheckCircle (green)
  - connecting: RefreshCw (yellow, spin)
  - disconnected: Unplug (red)
- 60秒間イベント未受信でstale connection検出
- Tailwind v4対応のカスタムCSSクラスを使用
- isConnectedをconnectionStateに置き換え（破壊的変更）
- タスク詳細画面のActionsエリアに右側余白追加（72px）