### PR TITLE
feat: implement non-blocking notification system with Ark UI

### DIFF
--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -53,41 +53,6 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     const { title, description, owner, repo, branch, baseBranch } = body;
 
-    // Validation
-    if (!title || !owner || !repo || !branch) {
-      return NextResponse.json(
-        {
-          errors: [
-            {
-              field: 'global',
-              message: 'Missing required fields: title, owner, repo, branch',
-            },
-          ],
-        },
-        { status: 400 }
-      );
-    }
-
-    // ブランチ名重複チェック
-    const existingTasks = await taskRepo.getTasks({ includeDeleted: false });
-    const duplicateTask = existingTasks.find(
-      (task) => task.owner === owner && task.repo === repo && task.branch === branch
-    );
-
-    if (duplicateTask) {
-      return NextResponse.json(
-        {
-          errors: [
-            {
-              field: 'branch',
-              message: `Branch "${branch}" already exists. Task "${duplicateTask.title}" (ID: ${duplicateTask.id}) is already using this branch.`,
-            },
-          ],
-        },
-        { status: 409 }
-      );
-    }
-
     // タスクを作成
     const newTask = await taskRepo.createTask({
       title,

--- a/src/app/api/tasks/validate/route.ts
+++ b/src/app/api/tasks/validate/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from 'next/server';
+import * as taskRepo from '@/lib/task-repository';
+
+// POST /api/tasks/validate
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { title, owner, repo, branch } = body;
+
+    // Validation
+    if (!title || !owner || !repo || !branch) {
+      return NextResponse.json(
+        {
+          valid: false,
+          errors: [
+            {
+              field: 'global',
+              message: 'Missing required fields: title, owner, repo, branch',
+            },
+          ],
+        },
+        { status: 400 }
+      );
+    }
+
+    // ブランチ名重複チェック
+    const existingTasks = await taskRepo.getTasks({ includeDeleted: false });
+    const duplicateTask = existingTasks.find(
+      (task) => task.owner === owner && task.repo === repo && task.branch === branch
+    );
+
+    if (duplicateTask) {
+      return NextResponse.json(
+        {
+          valid: false,
+          errors: [
+            {
+              field: 'branch',
+              message: `Branch "${branch}" already exists. Task "${duplicateTask.title}" (ID: ${duplicateTask.id}) is already using this branch.`,
+            },
+          ],
+        },
+        { status: 409 }
+      );
+    }
+
+    return NextResponse.json({ valid: true });
+  } catch (error) {
+    console.error('POST /api/tasks/validate error:', error);
+    return NextResponse.json(
+      {
+        valid: false,
+        errors: [{ field: 'global', message: 'Validation failed' }],
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
 import { ThemeProvider } from '@/contexts/ThemeContext';
 import { ConnectionStatus } from '@/components/ConnectionStatus';
+import { ToastProvider } from '@/components/ToastProvider';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -30,6 +31,7 @@ export default function RootLayout({
         <ThemeProvider>
           {children}
           <ConnectionStatus />
+          <ToastProvider />
         </ThemeProvider>
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -86,20 +86,15 @@ export default function Home() {
     }
   };
 
-  useEffect(() => {
-    loadData();
-  }, []);
+  // 初回ロード時のみデータを取得
+  const [isInitialLoad, setIsInitialLoad] = useState(true);
 
-  // Reload data when returning from Settings
   useEffect(() => {
-    const handleVisibilityChange = () => {
-      if (document.visibilityState === 'visible') {
-        loadData();
-      }
-    };
-
-    document.addEventListener('visibilitychange', handleVisibilityChange);
-    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+    if (isInitialLoad) {
+      loadData();
+      setIsInitialLoad(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // SSE統合
@@ -159,30 +154,6 @@ export default function Home() {
     }
   };
 
-  const handleAddTask = async (formData: {
-    title: string;
-    description: string;
-    owner: string;
-    repo: string;
-    branch: string;
-    baseBranch: string;
-  }) => {
-    const response = await fetch('/api/tasks', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(formData),
-    });
-
-    if (!response.ok) {
-      const data = await response.json();
-      // APIエラーレスポンス（正常なレスポンス）
-      return { success: false, errors: data.errors };
-    }
-
-    // SSE経由でtask:createdイベントが配信されるため、ここではstateを更新しない
-    return { success: true };
-  };
-
   const handleCloneRepository = async (cloneData: { gitUrl: string; authToken?: string }) => {
     try {
       const response = await fetch('/api/clone', {
@@ -211,7 +182,8 @@ export default function Home() {
     router.push(`/tasks/${taskId}`);
   };
 
-  if (isLoading) {
+  // 初回ロード時のみローディング表示
+  if (isLoading && tasks.length === 0) {
     return (
       <div className="h-screen flex items-center justify-center bg-theme-bg">
         <div className="text-center">
@@ -271,7 +243,6 @@ export default function Home() {
         mode="create"
         isOpen={isAddTaskDialogOpen}
         onClose={() => setIsAddTaskDialogOpen(false)}
-        onAdd={handleAddTask}
         repositories={repositories}
       />
     </div>

--- a/src/app/tasks/[id]/page.tsx
+++ b/src/app/tasks/[id]/page.tsx
@@ -13,6 +13,7 @@ import { ExecutionLogsChat } from '@/components/ExecutionLogsChat';
 import { TaskActions } from '@/components/TaskActions';
 import { LoadingSpinner } from '@/components/LoadingSpinner';
 import { useSSE } from '@/hooks/useSSE';
+import { useToast } from '@/hooks/useToast';
 
 interface TaskDetailPageProps {
   params: Promise<{
@@ -23,6 +24,7 @@ interface TaskDetailPageProps {
 export default function TaskDetailPage({ params }: TaskDetailPageProps) {
   const { id } = use(params);
   const router = useRouter();
+  const toast = useToast();
   const [task, setTask] = useState<Task | null>(null);
   const [tabs, setTabs] = useState<Tab[]>([]);
   const [activeTabId, setActiveTabId] = useState<string | undefined>();
@@ -32,6 +34,7 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
   const [viewMode, setViewMode] = useState<ViewMode>('split');
   const [isLoading, setIsLoading] = useState(true);
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
+  const [isInitialLoad, setIsInitialLoad] = useState(true);
 
   // Prompts管理をstateからrefに変更（再レンダリングを防止）
   const promptsRef = useRef<Record<string, string>>({});
@@ -65,9 +68,19 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
     }
   }, [activeTabId]);
 
-  // データロード
+  // データロード（初回ロード時のみ、またはIDが変わった時）
+  const prevIdRef = useRef<string | null>(null);
+
   useEffect(() => {
     const loadData = async () => {
+      // IDが変わった場合は再ロード
+      if (prevIdRef.current !== null && prevIdRef.current !== id) {
+        setIsInitialLoad(true);
+      }
+      prevIdRef.current = id;
+
+      if (!isInitialLoad) return;
+
       setIsLoading(true);
       try {
         // タスク取得
@@ -131,10 +144,12 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
         console.error('Failed to load data:', error);
       } finally {
         setIsLoading(false);
+        setIsInitialLoad(false);
       }
     };
 
     loadData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id]);
 
   // 全体再同期関数
@@ -323,6 +338,15 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
       }
     };
 
+    // task:deleted イベント
+    const handleTaskDeleted = (event: MessageEvent) => {
+      const { taskId } = JSON.parse(event.data) as { taskId: string };
+      // このタスクが削除された場合、一覧に戻る
+      if (taskId === id) {
+        router.push('/');
+      }
+    };
+
     eventSource.addEventListener('tab:updated', handleTabUpdated);
     eventSource.addEventListener('tab:deleted', handleTabDeleted);
     eventSource.addEventListener('tab:created', handleTabCreated);
@@ -330,6 +354,7 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
     eventSource.addEventListener('tab:messages:updated', handleTabMessagesUpdated);
     eventSource.addEventListener('resync:hint', handleResyncHint);
     eventSource.addEventListener('task:updated', handleTaskUpdated);
+    eventSource.addEventListener('task:deleted', handleTaskDeleted);
 
     return () => {
       eventSource.removeEventListener('tab:updated', handleTabUpdated);
@@ -339,8 +364,9 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
       eventSource.removeEventListener('tab:messages:updated', handleTabMessagesUpdated);
       eventSource.removeEventListener('resync:hint', handleResyncHint);
       eventSource.removeEventListener('task:updated', handleTaskUpdated);
+      eventSource.removeEventListener('task:deleted', handleTaskDeleted);
     };
-  }, [eventSource, id, activeTabId, tabs, tabSequences, triggerFullResync]);
+  }, [eventSource, id, activeTabId, tabs, tabSequences, triggerFullResync, router]);
 
   // タブのポーリング（running状態の場合のみ、SSE未接続時のフォールバック）
   useEffect(() => {
@@ -389,6 +415,8 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
 
   // タスク更新
   const handleTaskUpdate = async (taskId: string, updates: Partial<Task>) => {
+    const notificationId = toast.loading('Updating task...');
+
     try {
       const response = await fetch(`/api/tasks/${taskId}`, {
         method: 'PUT',
@@ -398,10 +426,14 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
 
       if (!response.ok) throw new Error('Failed to update task');
 
+      toast.success(notificationId, 'Successfully updated task');
+
       // SSE経由でtask:updatedイベントが配信されるため、ここではstateを更新しない
       return { success: true };
     } catch (error) {
       console.error('Failed to update task:', error);
+      const errorMessage = error instanceof Error ? error.message : 'Failed to update task';
+      toast.error(notificationId, 'Failed to update task', errorMessage);
       return { success: false, errors: [{ field: 'global', message: 'Failed to update task' }] };
     }
   };
@@ -494,24 +526,31 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
 
   // タスク削除
   const handleTaskDelete = async (taskId: string) => {
-    try {
-      const response = await fetch(`/api/tasks/${taskId}`, {
-        method: 'DELETE',
-      });
-
-      if (!response.ok) throw new Error('Failed to delete task');
-
-      // Kanbanに戻る
-      router.push('/');
-    } catch (error) {
+    // 削除API呼び出し（非同期）
+    fetch(`/api/tasks/${taskId}`, {
+      method: 'DELETE',
+    }).catch((error) => {
       console.error('Failed to delete task:', error);
-    }
+    });
+
+    // 即座に一覧に戻る
+    router.push('/');
   };
 
-  if (isLoading || !task) {
+  // 初回ロード時のみローディング表示
+  if (isLoading && !task) {
     return (
       <div className="h-screen flex items-center justify-center bg-theme-bg">
         <LoadingSpinner size="lg" message="Loading task..." />
+      </div>
+    );
+  }
+
+  // taskがnullの場合（エラー時など）
+  if (!task) {
+    return (
+      <div className="h-screen flex items-center justify-center bg-theme-bg">
+        <div className="text-center text-theme-fg">Task not found</div>
       </div>
     );
   }

--- a/src/components/AddTaskDialog.tsx
+++ b/src/components/AddTaskDialog.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useMemo, type FormEvent } from 'react';
 import type { Repository } from '@/lib/types';
 import { LoadingSpinner } from './LoadingSpinner';
+import { useToast } from '@/hooks/useToast';
 
 interface FieldError {
   field: string;
@@ -12,18 +13,10 @@ interface FieldError {
 interface AddTaskDialogProps {
   isOpen: boolean;
   onClose: () => void;
-  onAdd: (data: {
-    title: string;
-    description: string;
-    owner: string;
-    repo: string;
-    branch: string;
-    baseBranch: string;
-  }) => Promise<{ success: boolean; errors?: FieldError[] }>;
   repositories: Repository[];
 }
 
-export function AddTaskDialog({ isOpen, onClose, onAdd, repositories }: AddTaskDialogProps) {
+export function AddTaskDialog({ isOpen, onClose, repositories }: AddTaskDialogProps) {
   const [combinedRepo, setCombinedRepo] = useState('');
   const [formData, setFormData] = useState({
     title: '',
@@ -33,12 +26,13 @@ export function AddTaskDialog({ isOpen, onClose, onAdd, repositories }: AddTaskD
     branch: '',
     baseBranch: '',
   });
-  const [isLoading, setIsLoading] = useState(false);
+  const [isValidating, setIsValidating] = useState(false);
   const [branches, setBranches] = useState<string[]>([]);
   const [defaultBranch, setDefaultBranch] = useState('');
   const [isFetchingBranches, setIsFetchingBranches] = useState(false);
   const [branchError, setBranchError] = useState('');
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const toast = useToast();
 
   const repoOptions = useMemo(() => {
     return repositories.map((repo) => ({
@@ -103,40 +97,69 @@ export function AddTaskDialog({ isOpen, onClose, onAdd, repositories }: AddTaskD
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    setIsLoading(true);
+    setIsValidating(true);
     setFieldErrors({});
 
     try {
-      const result = await onAdd(formData);
+      // 1. バリデーションAPIを呼び出し（同期的に待つ）
+      const validateRes = await fetch('/api/tasks/validate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(formData),
+      });
+      const validateData = await validateRes.json();
 
-      if (result.success) {
-        onClose();
-        // Reset form
-        setCombinedRepo('');
-        setFormData({
-          title: '',
-          description: '',
-          owner: '',
-          repo: '',
-          branch: '',
-          baseBranch: '',
-        });
-      } else if (result.errors) {
-        // APIからのエラーレスポンス（正常なレスポンス）
+      if (!validateData.valid) {
+        // バリデーションエラー: ダイアログ内でエラー表示
         const errorsMap: Record<string, string> = {};
-        result.errors.forEach((err) => {
+        validateData.errors.forEach((err: FieldError) => {
           errorsMap[err.field] = err.message;
         });
         setFieldErrors(errorsMap);
+        setIsValidating(false);
+        return;
+      }
+
+      // 2. バリデーションOK: ダイアログを即座に閉じて、非同期でタスク作成
+      const taskData = { ...formData };
+
+      // ダイアログを即座に閉じる
+      onClose();
+      setCombinedRepo('');
+      setFormData({
+        title: '',
+        description: '',
+        owner: '',
+        repo: '',
+        branch: '',
+        baseBranch: '',
+      });
+      setIsValidating(false);
+
+      // 通知を表示してタスク作成開始
+      const notificationId = toast.loading('Creating task...', taskData.title);
+
+      // タスク作成APIを直接呼び出し（onAddを経由しない）
+      try {
+        const response = await fetch('/api/tasks', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(taskData),
+        });
+
+        if (!response.ok) {
+          throw new Error('Failed to create task');
+        }
+
+        toast.success(notificationId, 'Successfully created task', taskData.title);
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+        toast.error(notificationId, 'Failed to create task', errorMessage);
       }
     } catch (error) {
-      // 本当のエラー（ネットワークエラーなど）
-      console.error('Failed to create task:', error);
-      setFieldErrors({
-        global: error instanceof Error ? error.message : 'Failed to create task. Please try again.',
-      });
-    } finally {
-      setIsLoading(false);
+      setIsValidating(false);
+      const errorMessage = error instanceof Error ? error.message : 'Validation failed';
+      toast.error(undefined, 'Validation failed', errorMessage);
     }
   };
 
@@ -151,9 +174,9 @@ export function AddTaskDialog({ isOpen, onClose, onAdd, repositories }: AddTaskD
         className="bg-theme-card rounded-lg p-6 w-full max-w-2xl max-h-[90vh] overflow-y-auto relative"
         onClick={(e) => e.stopPropagation()}
       >
-        {isLoading && (
+        {isValidating && (
           <div className="absolute inset-0 bg-theme-card bg-opacity-90 rounded-lg flex items-center justify-center z-10">
-            <LoadingSpinner size="lg" message="Creating task..." />
+            <LoadingSpinner size="lg" message="Validating..." />
           </div>
         )}
 
@@ -173,7 +196,7 @@ export function AddTaskDialog({ isOpen, onClose, onAdd, repositories }: AddTaskD
               value={combinedRepo}
               onChange={(e) => handleRepositoryChange(e.target.value)}
               className="w-full pl-3 pr-10 py-2 border border-theme rounded text-theme-fg bg-theme-card"
-              disabled={isLoading}
+              disabled={isValidating}
             >
               <option value="">Select repository</option>
               {repoOptions.map((option) => (
@@ -193,7 +216,7 @@ export function AddTaskDialog({ isOpen, onClose, onAdd, repositories }: AddTaskD
               value={formData.title}
               onChange={(e) => setFormData({ ...formData, title: e.target.value })}
               className="w-full px-3 py-2 border border-theme rounded text-theme-fg bg-theme-card"
-              disabled={isLoading}
+              disabled={isValidating}
             />
           </div>
 
@@ -204,7 +227,7 @@ export function AddTaskDialog({ isOpen, onClose, onAdd, repositories }: AddTaskD
               value={formData.description}
               onChange={(e) => setFormData({ ...formData, description: e.target.value })}
               className="w-full px-3 py-2 border border-theme rounded h-24 text-theme-fg bg-theme-card"
-              disabled={isLoading}
+              disabled={isValidating}
             />
           </div>
 
@@ -221,7 +244,7 @@ export function AddTaskDialog({ isOpen, onClose, onAdd, repositories }: AddTaskD
                 value={formData.baseBranch}
                 onChange={(e) => setFormData({ ...formData, baseBranch: e.target.value })}
                 className="w-full h-10 pl-3 pr-10 border border-theme rounded text-theme-fg bg-theme-card"
-                disabled={isLoading}
+                disabled={isValidating}
               >
                 {branches.map((branch) => (
                   <option key={branch} value={branch}>
@@ -254,7 +277,7 @@ export function AddTaskDialog({ isOpen, onClose, onAdd, repositories }: AddTaskD
                 fieldErrors.branch ? 'border-red-500 input-error' : 'border-theme'
               }`}
               placeholder="feature/new-feature"
-              disabled={isLoading}
+              disabled={isValidating}
             />
             {fieldErrors.branch && (
               <p className="text-xs text-red-500 mt-1">{fieldErrors.branch}</p>
@@ -271,14 +294,14 @@ export function AddTaskDialog({ isOpen, onClose, onAdd, repositories }: AddTaskD
               type="button"
               onClick={onClose}
               className="px-4 py-2 border border-theme rounded text-theme-fg hover:bg-theme-card active:scale-95 cursor-pointer"
-              disabled={isLoading}
+              disabled={isValidating}
             >
               Cancel
             </button>
             <button
               type="submit"
               className="px-4 py-2 bg-primary text-white rounded active:scale-95 transition-transform disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
-              disabled={isLoading || isFetchingBranches}
+              disabled={isValidating || isFetchingBranches}
             >
               Create
             </button>

--- a/src/components/CloneRepositoryDialog.tsx
+++ b/src/components/CloneRepositoryDialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, type FormEvent } from 'react';
-import { LoadingSpinner } from './LoadingSpinner';
+import { useToast } from '@/hooks/useToast';
 
 interface CloneRepositoryDialogProps {
   isOpen: boolean;
@@ -17,20 +17,25 @@ export function CloneRepositoryDialog({
   isOnboarding = false,
 }: CloneRepositoryDialogProps) {
   const [gitUrl, setGitUrl] = useState('');
-  const [isLoading, setIsLoading] = useState(false);
+  const toast = useToast();
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    setIsLoading(true);
+
+    // ダイアログを即座に閉じる
+    onClose();
+    const url = gitUrl;
+    setGitUrl('');
+
+    // 非同期でclone処理を実行し、通知で進捗を表示
+    const notificationId = toast.loading('Cloning repository...', url);
+
     try {
-      await onClone({ gitUrl });
-      onClose();
-      // Reset form
-      setGitUrl('');
+      await onClone({ gitUrl: url });
+      toast.success(notificationId, 'Successfully cloned repository', url);
     } catch (error) {
-      console.error('Failed to clone repository:', error);
-    } finally {
-      setIsLoading(false);
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      toast.error(notificationId, 'Failed to clone repository', errorMessage);
     }
   };
 
@@ -39,18 +44,12 @@ export function CloneRepositoryDialog({
   return (
     <div
       className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50"
-      onClick={!isOnboarding && !isLoading ? onClose : undefined}
+      onClick={!isOnboarding ? onClose : undefined}
     >
       <div
         className="bg-theme-card rounded-lg p-6 w-full max-w-md relative"
         onClick={(e) => e.stopPropagation()}
       >
-        {isLoading && (
-          <div className="absolute inset-0 bg-theme-card bg-opacity-90 rounded-lg flex items-center justify-center z-10">
-            <LoadingSpinner size="lg" message="Cloning repository..." />
-          </div>
-        )}
-
         <h2 className="text-xl font-bold mb-4 text-theme-fg">Clone Repository</h2>
 
         <form onSubmit={handleSubmit} className="space-y-4">
@@ -63,7 +62,6 @@ export function CloneRepositoryDialog({
               value={gitUrl}
               onChange={(e) => setGitUrl(e.target.value)}
               className="w-full px-3 py-2 border border-theme rounded text-theme-fg bg-theme-card"
-              disabled={isLoading}
             />
             <p className="text-xs text-theme-muted mt-1">
               HTTPS or SSH形式のGit URLを入力してください
@@ -75,14 +73,12 @@ export function CloneRepositoryDialog({
               type="button"
               onClick={onClose}
               className="px-4 py-2 border border-theme rounded text-theme-fg hover:bg-theme-card active:scale-95 cursor-pointer"
-              disabled={isLoading}
             >
               Cancel
             </button>
             <button
               type="submit"
-              className="px-4 py-2 bg-primary text-white rounded active:scale-95 transition-transform disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
-              disabled={isLoading}
+              className="px-4 py-2 bg-primary text-white rounded active:scale-95 transition-transform cursor-pointer"
             >
               Clone
             </button>

--- a/src/components/TaskActions.tsx
+++ b/src/components/TaskActions.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import type { Task } from '@/lib/types';
 import { normalizeBranchName } from '@/lib/branch-utils';
 import { Code2, Terminal, Trash2, GitMerge, Loader2 } from 'lucide-react';
+import { useToast } from '@/hooks/useToast';
 
 interface TaskActionsProps {
   task: Task;
@@ -17,8 +18,7 @@ function getWorktreePath(task: Task): string {
 
 export function TaskActions({ task, onDelete }: TaskActionsProps) {
   const worktreePath = getWorktreePath(task);
-  const [isExecuting, setIsExecuting] = useState<string | null>(null);
-  const [isRebasing, setIsRebasing] = useState(false);
+  const toast = useToast();
   const [needsRebase, setNeedsRebase] = useState<boolean | undefined>(undefined);
   const [isCheckingRebase, setIsCheckingRebase] = useState(false);
 
@@ -52,7 +52,9 @@ export function TaskActions({ task, onDelete }: TaskActionsProps) {
   }, [task.id, task.worktreeStatus]);
 
   const handleCommand = async (commandType: 'vscode' | 'terminal') => {
-    setIsExecuting(commandType);
+    const commandLabel = commandType === 'vscode' ? 'VS Code' : 'Terminal';
+    const notificationId = toast.loading(`Opening ${commandLabel}...`, worktreePath);
+
     try {
       const response = await fetch('/api/commands/open', {
         method: 'POST',
@@ -68,13 +70,17 @@ export function TaskActions({ task, onDelete }: TaskActionsProps) {
       if (!response.ok) {
         throw new Error('Command execution failed');
       }
+
+      toast.success(notificationId, `Successfully opened ${commandLabel}`, worktreePath);
     } catch {
       // フォールバック: クリップボードにコピー
       const command = commandType === 'vscode' ? `code ${worktreePath}` : `cd ${worktreePath}`;
       await navigator.clipboard.writeText(command);
-      alert('Command execution failed. Command copied to clipboard instead.');
-    } finally {
-      setIsExecuting(null);
+      toast.info(
+        'Command copied to clipboard',
+        `Failed to open automatically. Command: ${command}`
+      );
+      toast.dismiss(notificationId);
     }
   };
 
@@ -87,7 +93,8 @@ export function TaskActions({ task, onDelete }: TaskActionsProps) {
       return;
     }
 
-    setIsRebasing(true);
+    const notificationId = toast.loading('Rebasing branch...', task.branch);
+
     try {
       const response = await fetch(`/api/tasks/${task.id}/rebase`, {
         method: 'POST',
@@ -98,31 +105,45 @@ export function TaskActions({ task, onDelete }: TaskActionsProps) {
       const data = await response.json();
 
       if (response.ok) {
-        alert(`✓ ${data.data.message}`);
+        toast.success(notificationId, 'Successfully rebased branch', task.branch);
       } else if (response.status === 409) {
         // conflict発生
         const conflictFiles = data.conflicts?.join('\n  - ') || 'unknown files';
-        alert(
-          `✗ Rebase failed due to conflicts:\n\n  - ${conflictFiles}\n\nPlease resolve conflicts manually.`
+        toast.error(
+          notificationId,
+          'Rebase failed due to conflicts',
+          `Conflicts in:\n${conflictFiles}`
         );
       } else {
-        alert(`✗ ${data.error || 'Rebase failed'}`);
+        toast.error(notificationId, 'Rebase failed', data.error || 'Unknown error');
       }
     } catch (error) {
-      alert(`✗ Failed to rebase: ${error instanceof Error ? error.message : 'Unknown error'}`);
-    } finally {
-      setIsRebasing(false);
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      toast.error(notificationId, 'Failed to rebase', errorMessage);
     }
   };
 
-  const handleDelete = async () => {
-    if (confirm(`Delete task "${task.title}"?\n\nThis will also delete the worktree and branch.`)) {
-      await onDelete(task.id);
+  const handleDelete = () => {
+    if (
+      !confirm(`Delete task "${task.title}"?\n\nThis will also delete the worktree and branch.`)
+    ) {
+      return;
     }
+
+    const notificationId = toast.loading('Deleting task...', task.title);
+
+    // 非同期で削除処理を実行（awaitしない）
+    onDelete(task.id)
+      .then(() => {
+        toast.success(notificationId, 'Successfully deleted task', task.title);
+      })
+      .catch((error) => {
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+        toast.error(notificationId, 'Failed to delete task', errorMessage);
+      });
   };
 
-  const isRebaseDisabled =
-    task.worktreeStatus !== 'created' || task.claudeState === 'running' || isRebasing;
+  const isRebaseDisabled = task.worktreeStatus !== 'created' || task.claudeState === 'running';
 
   return (
     <div>
@@ -138,20 +159,18 @@ export function TaskActions({ task, onDelete }: TaskActionsProps) {
 
         <button
           onClick={() => handleCommand('vscode')}
-          disabled={isExecuting !== null}
-          className="flex-1 px-4 py-2 rounded-lg font-medium text-sm cursor-pointer bg-primary-600 hover:bg-primary-hover text-white disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+          className="flex-1 px-4 py-2 rounded-lg font-medium text-sm cursor-pointer bg-primary-600 hover:bg-primary-hover text-white flex items-center justify-center gap-2"
         >
           <Code2 className="w-4 h-4" />
-          {isExecuting === 'vscode' ? 'Opening...' : 'Open VS Code'}
+          Open VS Code
         </button>
 
         <button
           onClick={() => handleCommand('terminal')}
-          disabled={isExecuting !== null}
-          className="flex-1 px-4 py-2 rounded-lg font-medium text-sm cursor-pointer bg-theme-card hover:bg-theme-hover text-theme-fg border border-theme disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+          className="flex-1 px-4 py-2 rounded-lg font-medium text-sm cursor-pointer bg-theme-card hover:bg-theme-hover text-theme-fg border border-theme flex items-center justify-center gap-2"
         >
           <Terminal className="w-4 h-4" />
-          {isExecuting === 'terminal' ? 'Opening...' : 'Open Terminal'}
+          Open Terminal
         </button>
 
         <button
@@ -188,20 +207,18 @@ export function TaskActions({ task, onDelete }: TaskActionsProps) {
         <div className="flex items-center gap-2">
           <button
             onClick={() => handleCommand('vscode')}
-            disabled={isExecuting !== null}
-            className="flex-1 px-4 py-2 rounded-lg font-medium text-sm cursor-pointer bg-primary-600 hover:bg-primary-hover text-white disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+            className="flex-1 px-4 py-2 rounded-lg font-medium text-sm cursor-pointer bg-primary-600 hover:bg-primary-hover text-white flex items-center justify-center gap-2"
           >
             <Code2 className="w-4 h-4" />
-            {isExecuting === 'vscode' ? 'Opening...' : 'Open VS Code'}
+            Open VS Code
           </button>
 
           <button
             onClick={() => handleCommand('terminal')}
-            disabled={isExecuting !== null}
-            className="flex-1 px-4 py-2 rounded-lg font-medium text-sm cursor-pointer bg-theme-card hover:bg-theme-hover text-theme-fg border border-theme disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+            className="flex-1 px-4 py-2 rounded-lg font-medium text-sm cursor-pointer bg-theme-card hover:bg-theme-hover text-theme-fg border border-theme flex items-center justify-center gap-2"
           >
             <Terminal className="w-4 h-4" />
-            {isExecuting === 'terminal' ? 'Opening...' : 'Open Terminal'}
+            Open Terminal
           </button>
 
           <button

--- a/src/components/TaskDialog.tsx
+++ b/src/components/TaskDialog.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useMemo, type FormEvent } from 'react';
 import type { Repository, Task } from '@/lib/types';
 import { LoadingSpinner } from './LoadingSpinner';
+import { useToast } from '@/hooks/useToast';
 
 interface FieldError {
   field: string;
@@ -34,7 +35,6 @@ interface TaskDialogProps {
 
   // Create mode用
   repositories?: Repository[];
-  onAdd?: (data: CreateTaskData) => Promise<{ success: boolean; errors?: FieldError[] }>;
 
   // Edit mode用
   task?: Task;
@@ -49,10 +49,11 @@ export function TaskDialog({
   isOpen,
   onClose,
   repositories = [],
-  onAdd,
   task,
   onUpdate,
 }: TaskDialogProps) {
+  const toast = useToast();
+
   // Create mode用のstate
   const [combinedRepo, setCombinedRepo] = useState('');
   const [branches, setBranches] = useState<string[]>([]);
@@ -158,23 +159,93 @@ export function TaskDialog({
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    setIsLoading(true);
     setFieldErrors({});
 
-    try {
-      let result: { success: boolean; errors?: FieldError[] };
+    if (mode === 'create') {
+      // Create mode: validation -> close dialog -> async create with notification
+      setIsLoading(true);
 
-      if (mode === 'create' && onAdd) {
-        result = await onAdd({
+      try {
+        // 1. Validation API (blocking)
+        const validateRes = await fetch('/api/tasks/validate', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            title: formData.title,
+            owner: formData.owner,
+            repo: formData.repo,
+            branch: formData.branch,
+          }),
+        });
+
+        const validateData = await validateRes.json();
+
+        if (!validateData.valid) {
+          const errorsMap: Record<string, string> = {};
+          validateData.errors.forEach((err: FieldError) => {
+            errorsMap[err.field] = err.message;
+          });
+          setFieldErrors(errorsMap);
+          setIsLoading(false);
+          return;
+        }
+
+        // 2. Close dialog immediately after validation
+        const taskData = {
           title: formData.title,
           description: formData.description,
           owner: formData.owner,
           repo: formData.repo,
           branch: formData.branch,
           baseBranch: formData.baseBranch,
+        };
+
+        onClose();
+        setCombinedRepo('');
+        setFormData({
+          title: '',
+          description: '',
+          owner: '',
+          repo: '',
+          branch: '',
+          baseBranch: '',
+          plan: undefined,
+          status: 'backlog',
+          effort: undefined,
+          order: undefined,
         });
-      } else if (mode === 'edit' && onUpdate && task) {
-        result = await onUpdate(task.id, {
+        setIsLoading(false);
+
+        // 3. Create task async with notification
+        const notificationId = toast.loading('Creating task...', taskData.title);
+
+        try {
+          const response = await fetch('/api/tasks', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(taskData),
+          });
+
+          if (!response.ok) {
+            throw new Error('Failed to create task');
+          }
+
+          toast.success(notificationId, 'Successfully created task', taskData.title);
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+          toast.error(notificationId, 'Failed to create task', errorMessage);
+        }
+      } catch (error) {
+        setIsLoading(false);
+        const errorMessage = error instanceof Error ? error.message : 'Validation failed';
+        toast.error(undefined, 'Validation failed', errorMessage);
+      }
+    } else if (mode === 'edit' && onUpdate && task) {
+      // Edit mode: use existing callback pattern
+      setIsLoading(true);
+
+      try {
+        const result = await onUpdate(task.id, {
           title: formData.title,
           description: formData.description,
           plan: formData.plan,
@@ -182,44 +253,25 @@ export function TaskDialog({
           effort: formData.effort,
           order: formData.order,
         });
-      } else {
-        throw new Error('Invalid mode or missing callbacks');
-      }
 
-      if (result.success) {
-        onClose();
-        // Reset form (Create modeのみ)
-        if (mode === 'create') {
-          setCombinedRepo('');
-          setFormData({
-            title: '',
-            description: '',
-            owner: '',
-            repo: '',
-            branch: '',
-            baseBranch: '',
-            plan: undefined,
-            status: 'backlog',
-            effort: undefined,
-            order: undefined,
+        if (result.success) {
+          onClose();
+        } else if (result.errors) {
+          const errorsMap: Record<string, string> = {};
+          result.errors.forEach((err) => {
+            errorsMap[err.field] = err.message;
           });
+          setFieldErrors(errorsMap);
         }
-      } else if (result.errors) {
-        // APIからのエラーレスポンス（正常なレスポンス）
-        const errorsMap: Record<string, string> = {};
-        result.errors.forEach((err) => {
-          errorsMap[err.field] = err.message;
+      } catch (error) {
+        console.error('Failed to update task:', error);
+        setFieldErrors({
+          global:
+            error instanceof Error ? error.message : 'Failed to update task. Please try again.',
         });
-        setFieldErrors(errorsMap);
+      } finally {
+        setIsLoading(false);
       }
-    } catch (error) {
-      // 本当のエラー（ネットワークエラーなど）
-      console.error('Failed to save task:', error);
-      setFieldErrors({
-        global: error instanceof Error ? error.message : 'Failed to save task. Please try again.',
-      });
-    } finally {
-      setIsLoading(false);
     }
   };
 

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { Toast as ArkToast, type ToastRootProps } from '@ark-ui/react/toast';
+import { CheckCircle, CircleAlert, Info, Loader2, X } from 'lucide-react';
+
+export type ToastType = 'loading' | 'success' | 'error' | 'info';
+
+interface ToastProps extends ToastRootProps {
+  type?: ToastType;
+  title?: string;
+  description?: string;
+  duration?: number;
+}
+
+const getIcon = (type?: ToastType) => {
+  switch (type) {
+    case 'loading':
+      return <Loader2 className="h-5 w-5 animate-spin text-blue-500" />;
+    case 'success':
+      return <CheckCircle className="h-5 w-5 text-green-500" />;
+    case 'error':
+      return <CircleAlert className="h-5 w-5 text-red-500" />;
+    case 'info':
+      return <Info className="h-5 w-5 text-blue-500" />;
+    default:
+      return <Info className="h-5 w-5 text-blue-500" />;
+  }
+};
+
+const getProgressBarColor = (type?: ToastType) => {
+  switch (type) {
+    case 'success':
+      return 'bg-green-500';
+    case 'info':
+      return 'bg-blue-500';
+    default:
+      return '';
+  }
+};
+
+export function Toast({ type, title, description, duration, ...props }: ToastProps) {
+  const shouldShowProgress =
+    (type === 'success' || type === 'info') && duration && duration !== Infinity;
+
+  return (
+    <ArkToast.Root
+      className="relative bg-theme-card border border-theme rounded-lg shadow-lg p-4 min-w-[320px] max-w-md group"
+      {...props}
+    >
+      {/* Progress Bar */}
+      {shouldShowProgress && (
+        <div
+          className={`absolute top-0 left-0 h-0.5 ${getProgressBarColor(type)} rounded-tl-lg`}
+          style={{
+            animation: `progress ${duration}ms linear`,
+            animationPlayState: 'running',
+          }}
+        />
+      )}
+
+      <div className="flex items-start gap-3">
+        {/* Icon */}
+        <div className="flex-shrink-0 mt-0.5">{getIcon(type)}</div>
+
+        {/* Content */}
+        <div className="flex-1 min-w-0">
+          {title && (
+            <ArkToast.Title className="text-sm font-semibold text-theme-fg">{title}</ArkToast.Title>
+          )}
+          {description && (
+            <ArkToast.Description className="text-sm text-theme-muted mt-1 break-words">
+              {description}
+            </ArkToast.Description>
+          )}
+        </div>
+
+        {/* Close Button */}
+        <ArkToast.CloseTrigger className="flex-shrink-0 text-theme-muted hover:text-theme-fg transition-colors">
+          <X className="h-4 w-4" />
+        </ArkToast.CloseTrigger>
+      </div>
+
+      {/* CSS for progress bar animation with pause on hover */}
+      <style jsx>{`
+        @keyframes progress {
+          from {
+            width: 100%;
+          }
+          to {
+            width: 0%;
+          }
+        }
+
+        .group:hover div[style*='animation'] {
+          animation-play-state: paused !important;
+        }
+      `}</style>
+    </ArkToast.Root>
+  );
+}

--- a/src/components/ToastProvider.tsx
+++ b/src/components/ToastProvider.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { Toaster } from '@ark-ui/react/toast';
+import { Portal } from '@ark-ui/react/portal';
+import { toaster } from '@/lib/toaster';
+import { Toast } from '@/components/Toast';
+
+export function ToastProvider() {
+  return (
+    <Portal>
+      <Toaster toaster={toaster}>
+        {(toast) => (
+          <Toast
+            key={toast.id}
+            type={toast.type as 'loading' | 'success' | 'error' | 'info'}
+            title={toast.title as string}
+            description={toast.description as string}
+            duration={toast.duration}
+          />
+        )}
+      </Toaster>
+    </Portal>
+  );
+}

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -1,0 +1,68 @@
+'use client';
+
+import { toaster } from '@/lib/toaster';
+import type { ToastType } from '@/components/Toast';
+
+export const useToast = () => {
+  const loading = (title: string, description?: string): string => {
+    return toaster.create({
+      type: 'loading' as ToastType,
+      title,
+      description,
+      duration: Infinity,
+    });
+  };
+
+  const success = (id: string | undefined, title: string, description?: string): string => {
+    if (id) {
+      toaster.update(id, {
+        type: 'success' as ToastType,
+        title,
+        description,
+        duration: 5000,
+      });
+      return id;
+    } else {
+      return toaster.create({
+        type: 'success' as ToastType,
+        title,
+        description,
+        duration: 5000,
+      });
+    }
+  };
+
+  const error = (id: string | undefined, title: string, description?: string): string => {
+    if (id) {
+      toaster.update(id, {
+        type: 'error' as ToastType,
+        title,
+        description,
+        duration: Infinity,
+      });
+      return id;
+    } else {
+      return toaster.create({
+        type: 'error' as ToastType,
+        title,
+        description,
+        duration: Infinity,
+      });
+    }
+  };
+
+  const info = (title: string, description?: string): string => {
+    return toaster.create({
+      type: 'info' as ToastType,
+      title,
+      description,
+      duration: 5000,
+    });
+  };
+
+  const dismiss = (id: string) => {
+    toaster.dismiss(id);
+  };
+
+  return { loading, success, error, info, dismiss };
+};

--- a/src/lib/toaster.ts
+++ b/src/lib/toaster.ts
@@ -1,0 +1,10 @@
+'use client';
+
+import { createToaster } from '@ark-ui/react/toast';
+
+export const toaster = createToaster({
+  placement: 'bottom-end',
+  overlap: true,
+  gap: 16,
+  max: 5,
+});


### PR DESCRIPTION
Implemented a comprehensive toast notification system to improve UX by eliminating blocking operations:

- Add Ark UI toast notification system with progress bar
  - Auto-close after 5 seconds for success/info
  - Pause countdown on mouse hover
  - Maximum 5 toasts displayed
  - Type-specific icons (loading, success, error, info)

- Separate validation from task creation
  - New validation API endpoint (/api/tasks/validate)
  - Validation errors shown in dialog
  - Task creation happens async with notifications

- Apply notifications to all side-effect actions
  - Clone repository: non-blocking with progress notification
  - Create task: validate then async create
  - Update task: show update progress
  - Delete task: immediate navigation with notification
  - Rebase: show progress and conflict details
  - Open commands: notify success or copy to clipboard

- Implement data caching for task list and detail pages
  - Load data only on initial visit
  - Update via SSE events
  - No unnecessary reloads on page revisits