### PR TITLE
fix: remove redundant result message content from logs

### DIFF
--- a/src/lib/ui-message-converter.ts
+++ b/src/lib/ui-message-converter.ts
@@ -534,7 +534,7 @@ export class UIMessageConverter {
         content: {
           type: 'system_event',
           event: 'session_completed',
-          description: msg.result || 'Session completed successfully',
+          description: 'Session completed successfully',
         },
         metadata: {
           sdkMessageUuids: msg.uuid ? [msg.uuid] : [],


### PR DESCRIPTION
Remove msg.result from session completion display to avoid showing redundant content that often duplicates the previous assistant message. Now shows a simple "Session completed successfully" message instead.