### PR TITLE
feat: convert task cards to links for better navigation

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -178,10 +178,6 @@ export default function Home() {
     setSearchQuery(filters.search);
   };
 
-  const handleTaskClick = (taskId: string) => {
-    router.push(`/tasks/${taskId}`);
-  };
-
   // 初回ロード時のみローディング表示
   if (isLoading && tasks.length === 0) {
     return (
@@ -210,7 +206,6 @@ export default function Home() {
         <KanbanBoard
           tasks={filteredTasks}
           onTaskMove={handleTaskMove}
-          onTaskClick={handleTaskClick}
           onAddTaskClick={() => setIsAddTaskDialogOpen(true)}
           nextStep={onboardingState.nextStep}
           isAddTaskDialogOpen={isAddTaskDialogOpen}

--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -7,7 +7,6 @@ import { KanbanColumn } from './KanbanColumn';
 interface KanbanBoardProps {
   tasks: Task[];
   onTaskMove: (taskId: string, newStatus: Task['status']) => void;
-  onTaskClick?: (taskId: string) => void;
   onAddTaskClick?: () => void;
   nextStep?: 'clone' | 'env' | 'task' | 'complete';
   isAddTaskDialogOpen?: boolean;
@@ -17,7 +16,6 @@ interface KanbanBoardProps {
 export function KanbanBoard({
   tasks,
   onTaskMove,
-  onTaskClick,
   onAddTaskClick,
   nextStep,
   isAddTaskDialogOpen = false,
@@ -68,31 +66,15 @@ export function KanbanBoard({
           title="Backlog"
           status="backlog"
           tasks={backlogTasks}
-          onTaskClick={onTaskClick}
           onAddTaskClick={onAddTaskClick}
           nextStep={nextStep}
           isAddTaskDialogOpen={isAddTaskDialogOpen}
           hasApiKey={hasApiKey}
         />
-        <KanbanColumn
-          title="Planning"
-          status="planning"
-          tasks={planningTasks}
-          onTaskClick={onTaskClick}
-        />
-        <KanbanColumn
-          title="Coding"
-          status="coding"
-          tasks={codingTasks}
-          onTaskClick={onTaskClick}
-        />
-        <KanbanColumn
-          title="Reviewing"
-          status="reviewing"
-          tasks={reviewingTasks}
-          onTaskClick={onTaskClick}
-        />
-        <KanbanColumn title="Done" status="done" tasks={doneTasks} onTaskClick={onTaskClick} />
+        <KanbanColumn title="Planning" status="planning" tasks={planningTasks} />
+        <KanbanColumn title="Coding" status="coding" tasks={codingTasks} />
+        <KanbanColumn title="Reviewing" status="reviewing" tasks={reviewingTasks} />
+        <KanbanColumn title="Done" status="done" tasks={doneTasks} />
       </div>
     </DragDropContext>
   );

--- a/src/components/KanbanColumn.tsx
+++ b/src/components/KanbanColumn.tsx
@@ -9,7 +9,6 @@ interface KanbanColumnProps {
   title: string;
   status: 'backlog' | 'planning' | 'coding' | 'reviewing' | 'done';
   tasks: Task[];
-  onTaskClick?: (taskId: string) => void;
   onAddTaskClick?: () => void;
   nextStep?: 'clone' | 'env' | 'task' | 'complete';
   isAddTaskDialogOpen?: boolean;
@@ -20,7 +19,6 @@ export function KanbanColumn({
   title,
   status,
   tasks,
-  onTaskClick,
   onAddTaskClick,
   nextStep,
   isAddTaskDialogOpen = false,
@@ -72,11 +70,7 @@ export function KanbanColumn({
                     {...provided.draggableProps}
                     {...provided.dragHandleProps}
                   >
-                    <TaskCard
-                      task={task}
-                      isDragging={snapshot.isDragging}
-                      onTaskClick={onTaskClick}
-                    />
+                    <TaskCard task={task} isDragging={snapshot.isDragging} />
                   </div>
                 )}
               </Draggable>

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import type { Task } from '@/lib/types';
 import { ClaudeState } from '@/components/ClaudeState';
 import { getClaudeStatus } from '@/lib/claude-status';
@@ -8,23 +9,32 @@ import { MessageCircle } from 'lucide-react';
 interface TaskCardProps {
   task: Task;
   isDragging: boolean;
-  onTaskClick?: (taskId: string) => void;
 }
 
-export function TaskCard({ task, isDragging, onTaskClick }: TaskCardProps) {
+export function TaskCard({ task, isDragging }: TaskCardProps) {
   const tabs = task.tabs || [];
   const isClaudeRunning = tabs.some((tab) => tab.status === 'running');
   const totalUserMessages = tabs.reduce((sum, tab) => sum + (tab.promptCount ?? 0), 0);
 
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    // ドラッグ中はリンク遷移を防止
+    if (isDragging) {
+      e.preventDefault();
+      return;
+    }
+    // 通常クリック、middle click、Cmd+clickなどは全てブラウザのデフォルト動作に任せる
+  };
+
   return (
-    <div
+    <Link
+      href={`/tasks/${task.id}`}
+      onClick={handleClick}
       className={`
-        bg-theme-card border border-theme rounded-lg p-4 cursor-pointer
-        hover:border-primary
+        block bg-theme-card border border-theme rounded-lg p-4 cursor-grab active:cursor-grabbing
+        hover:border-primary transition-colors
         ${isDragging ? 'shadow-xl rotate-2' : ''}
         ${isClaudeRunning ? 'opacity-50 bg-theme-hover' : ''}
       `}
-      onClick={() => onTaskClick?.(task.id)}
     >
       {/* Order Badge */}
       {task.order !== undefined && (
@@ -77,6 +87,6 @@ export function TaskCard({ task, isDragging, onTaskClick }: TaskCardProps) {
           )}
         </div>
       </div>
-    </div>
+    </Link>
   );
 }


### PR DESCRIPTION
- Replace div with Next.js Link component in TaskCard
- Enable middle-click, Cmd+click, Shift+click for opening in new tabs
- Add cursor-grab styling to indicate draggable items
- Prevent link navigation during drag operations
- Remove obsolete onTaskClick prop from component hierarchy