### PR TITLE
fix: update rebase button state after successful rebase

### DIFF
--- a/src/components/TaskActions.tsx
+++ b/src/components/TaskActions.tsx
@@ -105,6 +105,8 @@ export function TaskActions({ task, onDelete }: TaskActionsProps) {
       const data = await response.json();
 
       if (response.ok) {
+        // rebase成功後、needsRebaseをfalseに設定
+        setNeedsRebase(false);
         toast.success(notificationId, 'Successfully rebased branch', task.branch);
       } else if (response.status === 409) {
         // conflict発生


### PR DESCRIPTION
rebase実行後にneedsRebaseをfalseに更新することで、
ボタンの表示状態を正しく制御する。

- rebase成功時にsetNeedsRebase(false)を呼び出し
- ボタンがprimary(青)からdefault(グレー)に変わる
- 次回rebaseが必要になるまで目立たない状態を保つ