### PR TITLE
feat: add copy button to code blocks in execution logs

### DIFF
--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useState } from 'react';
+import { Copy, Check } from 'lucide-react';
+
+interface CodeBlockProps {
+  language?: string;
+  code: string;
+  children: React.ReactNode;
+}
+
+export function CodeBlock({ language, code, children }: CodeBlockProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (error) {
+      console.error('Failed to copy code:', error);
+    }
+  };
+
+  return (
+    <div className="relative group">
+      <button
+        onClick={handleCopy}
+        className="absolute top-2 right-2 p-1.5 rounded bg-theme-card hover:bg-theme-hover transition-colors opacity-80 hover:opacity-100"
+        title={copied ? 'Copied!' : 'Copy code'}
+        aria-label={copied ? 'Copied to clipboard' : 'Copy code to clipboard'}
+      >
+        {copied ? (
+          <Check className="w-4 h-4 text-success" />
+        ) : (
+          <Copy className="w-4 h-4 text-theme-fg" />
+        )}
+      </button>
+      <pre>
+        <code className={language ? `language-${language}` : ''}>{children}</code>
+      </pre>
+    </div>
+  );
+}

--- a/src/components/ExecutionLogsChat.tsx
+++ b/src/components/ExecutionLogsChat.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState, useMemo } from 'react';
 import ReactMarkdown from 'react-markdown';
+import type { Components } from 'react-markdown';
 import {
   ChevronDown,
   ChevronUp,
@@ -18,6 +19,30 @@ import { UIMessageConverter } from '@/lib/ui-message-converter';
 import { useTheme } from '@/contexts/ThemeContext';
 import { ClaudeState } from '@/components/ClaudeState';
 import { getClaudeStatus } from '@/lib/claude-status';
+import { CodeBlock } from '@/components/CodeBlock';
+
+// ReactMarkdown用のカスタムコンポーネント
+const markdownComponents: Components = {
+  code: (props) => {
+    const { className, children } = props;
+    const match = /language-(\w+)/.exec(className || '');
+    const language = match ? match[1] : '';
+    const codeString = String(children).replace(/\n$/, '');
+
+    // inline属性がない場合はコードブロック（複数行）とみなす
+    const isCodeBlock = className && className.startsWith('language-');
+
+    if (isCodeBlock && codeString) {
+      return (
+        <CodeBlock language={language} code={codeString}>
+          {children}
+        </CodeBlock>
+      );
+    }
+
+    return <code {...props}>{children}</code>;
+  },
+};
 
 // セッション完了状態を判定するヘルパー関数
 function isSessionCompleted(rawMessages?: unknown[]): boolean {
@@ -209,7 +234,7 @@ function UIMessageItem({
                 <div className="flex justify-start items-center gap-2">
                   <div className="inline-block text-left rounded-lg p-2 bg-theme-card max-w-full">
                     <div className="prose prose-pre:overflow-x-hidden prose-pre:whitespace-pre-wrap prose-pre:break-words prose-code:break-words prose-a:break-all max-w-none text-theme-fg text-xs break-words overflow-wrap-anywhere">
-                      <ReactMarkdown>{block.content}</ReactMarkdown>
+                      <ReactMarkdown components={markdownComponents}>{block.content}</ReactMarkdown>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
Add a copy-to-clipboard feature for code blocks displayed in the task detail execution logs.

Changes:
- Create CodeBlock component with copy button
- Integrate custom code rendering in ExecutionLogsChat
- Use lucide-react Copy/Check icons
- Support dark mode with Tailwind v4 theme variables
- Add accessibility attributes (title, aria-label)