### PR TITLE
fix: unify Toast loading spinner color with app primary color

### DIFF
--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -15,7 +15,7 @@ interface ToastProps extends ToastRootProps {
 const getIcon = (type?: ToastType) => {
   switch (type) {
     case 'loading':
-      return <Loader2 className="h-5 w-5 animate-spin text-blue-500" />;
+      return <Loader2 className="h-5 w-5 animate-spin text-primary" />;
     case 'success':
       return <CheckCircle className="h-5 w-5 text-green-500" />;
     case 'error':


### PR DESCRIPTION
Change Toast loading spinner from blue (text-blue-500) to green (text-primary) to match other spinners in the app (LoadingSpinner, ClaudeState).