### PR TITLE
fix: enable updating all task fields in updateTask function

### DIFF
--- a/src/lib/repositories/task.ts
+++ b/src/lib/repositories/task.ts
@@ -149,9 +149,13 @@ export async function updateTask(
   const updatedTask = await prisma.task.update({
     where: { id },
     data: {
-      ...(updates.status && { status: updates.status }),
-      ...(updates.title && { title: updates.title }),
-      ...(updates.branch && { branch: updates.branch }),
+      ...(updates.status !== undefined && { status: updates.status }),
+      ...(updates.title !== undefined && { title: updates.title }),
+      ...(updates.description !== undefined && { description: updates.description }),
+      ...(updates.branch !== undefined && { branch: updates.branch }),
+      ...(updates.plan !== undefined && { plan: updates.plan }),
+      ...(updates.effort !== undefined && { effort: updates.effort }),
+      ...(updates.order !== undefined && { order: updates.order }),
     },
     include: {
       tabs: {


### PR DESCRIPTION
タスク更新機能で description, plan, effort, order フィールドが
更新できなかった問題を修正。

- description（説明）の更新を追加
- plan（計画）の更新を追加
- effort（工数）の更新を追加
- order（優先順位）の更新を追加
- falsyな値も正しく更新できるよう && を !== undefined に変更