### PR TITLE
feat: make all Kanban columns equal width

### DIFF
--- a/src/components/KanbanColumn.tsx
+++ b/src/components/KanbanColumn.tsx
@@ -27,7 +27,7 @@ export function KanbanColumn({
   const showAddButton = status === 'backlog' && onAddTaskClick;
 
   return (
-    <div className="min-w-64 flex flex-col bg-theme-hover rounded-lg p-4 h-full">
+    <div className="flex-1 flex flex-col bg-theme-hover rounded-lg p-4 h-full min-w-64">
       {/* ヘッダー */}
       <div className="flex items-center justify-between mb-4 flex-shrink-0">
         <h2 className="text-lg font-semibold text-theme-fg">{title}</h2>


### PR DESCRIPTION
Apply flex-1 to KanbanColumn to ensure all columns (Backlog, Planning, Coding, Reviewing, Done) have equal width while maintaining minimum width constraint.