### PR TITLE
Fix: Broadcast SSE event when task status is updated

### DIFF
--- a/src/app/api/tasks/[id]/status/route.ts
+++ b/src/app/api/tasks/[id]/status/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import * as taskRepo from '@/lib/repositories/task';
 import type { Task } from '@/lib/types';
+import { sseManager } from '@/lib/sse-manager';
 
 // PUT /api/tasks/:id/status - Transition task status
 export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
@@ -22,6 +23,9 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
     if (!updatedTask) {
       return NextResponse.json({ error: 'Task not found' }, { status: 404 });
     }
+
+    // SSE broadcast
+    sseManager.broadcast('task:updated', updatedTask);
 
     return NextResponse.json({ data: { task: updatedTask } });
   } catch (error) {


### PR DESCRIPTION
Add sseManager.broadcast('task:updated') call in status update API endpoint to ensure task status updates are reflected in real-time on the UI.