### PR TITLE
Disable Request Planning/Implementation buttons when Claude is running

### DIFF
--- a/src/components/TaskActions.tsx
+++ b/src/components/TaskActions.tsx
@@ -269,7 +269,8 @@ PR作成後、タスクをreviewingステータスに更新してください。
           {task.status === 'backlog' && (
             <button
               onClick={handleRequestPlanning}
-              className="px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-hover flex items-center gap-2 font-medium text-sm"
+              disabled={isClaudeRunning}
+              className="px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-hover flex items-center gap-2 font-medium text-sm disabled:opacity-50 disabled:cursor-not-allowed"
               title="Request planning from Claude"
             >
               <FileText className="w-4 h-4" />
@@ -303,7 +304,8 @@ PR作成後、タスクをreviewingステータスに更新してください。
               </button>
               <button
                 onClick={handleRequestImplementation}
-                className="px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-hover flex items-center gap-2 font-medium text-sm"
+                disabled={isClaudeRunning}
+                className="px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-hover flex items-center gap-2 font-medium text-sm disabled:opacity-50 disabled:cursor-not-allowed"
                 title="Request implementation from Claude"
               >
                 <Play className="w-4 h-4" />
@@ -338,7 +340,8 @@ PR作成後、タスクをreviewingステータスに更新してください。
               </button>
               <button
                 onClick={handleRequestImplementation}
-                className="px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-hover flex items-center gap-2 font-medium text-sm"
+                disabled={isClaudeRunning}
+                className="px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-hover flex items-center gap-2 font-medium text-sm disabled:opacity-50 disabled:cursor-not-allowed"
                 title="Request fix implementation from Claude"
               >
                 <Play className="w-4 h-4" />


### PR DESCRIPTION
Prevent users from accidentally sending multiple requests by disabling the action buttons when Claude is in running state.

Changes:
- Add disabled={isClaudeRunning} to Request Planning button (backlog status)
- Add disabled={isClaudeRunning} to Request Implementation button (planning status)
- Add disabled={isClaudeRunning} to Request Implementation (Fix) button (reviewing status)
- Apply disabled:opacity-50 and disabled:cursor-not-allowed styles for visual feedback