### PR TITLE
Optimize batch delete performance and remove completedAt field

### DIFF
--- a/prisma/migrations/20260131171847_remove_completed_at/migration.sql
+++ b/prisma/migrations/20260131171847_remove_completed_at/migration.sql
@@ -1,0 +1,34 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_tasks" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "owner" TEXT NOT NULL,
+    "repo" TEXT NOT NULL,
+    "branch" TEXT NOT NULL,
+    "base_branch" TEXT NOT NULL,
+    "base_branch_commit" TEXT,
+    "repo_id" TEXT NOT NULL,
+    "worktree_status" TEXT NOT NULL,
+    "requirement" TEXT,
+    "design" TEXT,
+    "procedure" TEXT,
+    "pull_request_url" TEXT,
+    "effort" INTEGER,
+    "order" INTEGER,
+    "deleted_at" DATETIME,
+    "created_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" DATETIME NOT NULL,
+    CONSTRAINT "tasks_repo_id_fkey" FOREIGN KEY ("repo_id") REFERENCES "repositories" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_tasks" ("id", "title", "description", "status", "owner", "repo", "branch", "base_branch", "base_branch_commit", "repo_id", "worktree_status", "requirement", "design", "procedure", "pull_request_url", "effort", "order", "deleted_at", "created_at", "updated_at") SELECT "id", "title", "description", "status", "owner", "repo", "branch", "base_branch", "base_branch_commit", "repo_id", "worktree_status", "requirement", "design", "procedure", "pull_request_url", "effort", "order", "deleted_at", "created_at", "updated_at" FROM "tasks";
+DROP TABLE "tasks";
+ALTER TABLE "new_tasks" RENAME TO "tasks";
+CREATE INDEX "tasks_owner_repo_idx" ON "tasks"("owner", "repo");
+CREATE INDEX "tasks_status_idx" ON "tasks"("status");
+CREATE INDEX "tasks_deleted_at_idx" ON "tasks"("deleted_at");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,9 +45,6 @@ model Task {
   // Pull Request情報
   pullRequestUrl String?   @map("pull_request_url")
 
-  // 完了日時
-  completedAt    DateTime? @map("completed_at")
-
   effort         Int?
   order          Int?
   deletedAt      DateTime? @map("deleted_at")

--- a/src/app/api/tasks/batch-delete/route.ts
+++ b/src/app/api/tasks/batch-delete/route.ts
@@ -15,17 +15,14 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Invalid daysAgo parameter' }, { status: 400 });
     }
 
-    // 削除対象タスクの抽出（completedAt < now - daysAgo days かつ status = done）
+    // 削除対象タスクの抽出（updatedAt < now - daysAgo days かつ status = done）
     const cutoffDate = new Date();
     cutoffDate.setDate(cutoffDate.getDate() - daysAgo);
 
-    const allTasks = await taskRepo.getTasks({ includeDeleted: false });
-    const targetTasks = allTasks.filter((task) => {
-      if (task.status !== 'done' || !task.completedAt) {
-        return false;
-      }
-      const completedDate = new Date(task.completedAt);
-      return completedDate < cutoffDate;
+    const targetTasks = await taskRepo.getTasks({
+      includeDeleted: false,
+      status: 'done',
+      updatedBefore: cutoffDate,
     });
 
     const targetTaskIds = targetTasks.map((task) => task.id);
@@ -43,10 +40,14 @@ export async function POST(request: NextRequest) {
       },
     });
 
-    // バックグラウンドで削除処理を実行
+    // バックグラウンドで削除処理を実行（最大8件の並行実行）
     // （Next.jsの制約上、ここで直接実行するが、本来はワーカーやキューを使うべき）
     setImmediate(async () => {
-      for (const task of targetTasks) {
+      const MAX_CONCURRENT = 8;
+      let index = 0;
+      const executing: Promise<void>[] = [];
+
+      const deleteTask = async (task: (typeof targetTasks)[0]) => {
         try {
           // DBから削除
           const success = await taskRepo.deleteTask(task.id);
@@ -65,9 +66,36 @@ export async function POST(request: NextRequest) {
         } catch (error) {
           console.error(`Failed to delete task ${task.id}:`, error);
           // エラーが発生してもbatchIdを含めてbroadcast（失敗として通知）
-          sseManager.broadcast('task:delete:error', { id: task.id, batchId, error: String(error) });
+          sseManager.broadcast('task:delete:error', {
+            id: task.id,
+            batchId,
+            error: String(error),
+          });
+        }
+      };
+
+      while (index < targetTasks.length) {
+        // 並行実行数が上限に達していない場合、新しいタスクを開始
+        while (index < targetTasks.length && executing.length < MAX_CONCURRENT) {
+          const task = targetTasks[index];
+          index++;
+
+          const promise = deleteTask(task).then(() => {
+            // 完了したら実行中リストから削除
+            executing.splice(executing.indexOf(promise), 1);
+          });
+
+          executing.push(promise);
+        }
+
+        // 少なくとも1つのタスクが完了するまで待機
+        if (executing.length > 0) {
+          await Promise.race(executing);
         }
       }
+
+      // 残りの実行中タスクを全て完了するまで待機
+      await Promise.all(executing);
     });
 
     return response;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -109,7 +109,7 @@ export default function Home() {
   const { eventSource } = useSSE();
 
   // バッチ削除
-  const { isDeleting, deletedCount, totalCount, isCompleted, startBatchDelete, reset } =
+  const { isDeleting, deletedCount, errorCount, totalCount, isCompleted, startBatchDelete, reset } =
     useBatchDelete();
 
   useEffect(() => {
@@ -201,36 +201,50 @@ export default function Home() {
   useEffect(() => {
     if (!isDeleting && !isCompleted) return;
 
-    if (isDeleting) {
-      // 進捗更新
-      toaster.update('batch-delete-progress', {
-        type: 'loading',
-        title: 'Deleting tasks...',
-        description: `${deletedCount} / ${totalCount}`,
-        duration: Infinity,
-      });
-    }
+    // マイクロタスクでtoaster操作を実行（Reactのレンダリング外で実行）
+    queueMicrotask(() => {
+      if (isDeleting) {
+        // 進捗更新
+        const description =
+          errorCount > 0
+            ? `${deletedCount} / ${totalCount} (${errorCount} failed)`
+            : `${deletedCount} / ${totalCount}`;
 
-    if (isCompleted) {
-      // 完了通知
-      toaster.dismiss('batch-delete-progress');
-      toaster.create({
-        type: 'success',
-        title: (
-          <div className="flex items-center gap-2">
-            <CircleCheck className="w-5 h-5" />
-            <span>Deleted {totalCount} tasks</span>
-          </div>
-        ),
-        duration: 3000,
-      });
+        toaster.update('batch-delete-progress', {
+          type: 'loading',
+          title: 'Deleting tasks...',
+          description,
+          duration: Infinity,
+        });
+      }
 
-      // リセット
-      setTimeout(() => {
-        reset();
-      }, 3000);
-    }
-  }, [isDeleting, isCompleted, deletedCount, totalCount, reset]);
+      if (isCompleted) {
+        // 完了通知
+        toaster.dismiss('batch-delete-progress');
+
+        const successMessage =
+          errorCount > 0
+            ? `Deleted ${deletedCount} tasks (${errorCount} failed)`
+            : `Deleted ${deletedCount} tasks`;
+
+        toaster.create({
+          type: errorCount > 0 ? 'warning' : 'success',
+          title: (
+            <div className="flex items-center gap-2">
+              <CircleCheck className="w-5 h-5" />
+              <span>{successMessage}</span>
+            </div>
+          ),
+          duration: 5000,
+        });
+
+        // リセット
+        setTimeout(() => {
+          reset();
+        }, 5000);
+      }
+    });
+  }, [isDeleting, isCompleted, deletedCount, errorCount, totalCount, reset]);
 
   // Handler functions
   const handleTaskMove = async (taskId: string, newStatus: Task['status']) => {
@@ -281,7 +295,8 @@ export default function Home() {
     try {
       const result = await startBatchDelete(daysAgo);
 
-      if (result.totalCount === 0) {
+      // 削除対象が0件の場合は通知のみ表示して終了
+      if (!result || result.totalCount === 0) {
         toaster.create({
           type: 'info',
           title: 'No tasks to delete',
@@ -340,6 +355,7 @@ export default function Home() {
           onTaskMove={handleTaskMove}
           onAddTaskClick={() => setIsAddTaskDialogOpen(true)}
           onBatchDeleteClick={() => setIsBatchDeleteDialogOpen(true)}
+          isBatchDeleting={isDeleting}
           nextStep={onboardingState.nextStep}
           isAddTaskDialogOpen={isAddTaskDialogOpen}
           hasApiKey={

--- a/src/components/BatchDeleteDialog.tsx
+++ b/src/components/BatchDeleteDialog.tsx
@@ -40,7 +40,7 @@ export function BatchDeleteDialog({
             min="1"
             value={daysAgo}
             onChange={(e) => setDaysAgo(Number(e.target.value))}
-            className="w-16 px-2 py-1 mx-1 border border-theme-border rounded bg-theme-bg text-theme-fg text-center"
+            className="w-16 px-2 py-1 mx-1 border border-theme rounded bg-theme-card text-theme-fg text-center"
           />{' '}
           days ago?
         </p>

--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -9,6 +9,7 @@ interface KanbanBoardProps {
   onTaskMove: (taskId: string, newStatus: Task['status']) => void;
   onAddTaskClick?: () => void;
   onBatchDeleteClick?: () => void;
+  isBatchDeleting?: boolean;
   nextStep?: 'clone' | 'env' | 'task' | 'complete';
   isAddTaskDialogOpen?: boolean;
   hasApiKey?: boolean;
@@ -19,6 +20,7 @@ export function KanbanBoard({
   onTaskMove,
   onAddTaskClick,
   onBatchDeleteClick,
+  isBatchDeleting = false,
   nextStep,
   isAddTaskDialogOpen = false,
   hasApiKey = false,
@@ -81,6 +83,7 @@ export function KanbanBoard({
           status="done"
           tasks={doneTasks}
           onBatchDeleteClick={onBatchDeleteClick}
+          isBatchDeleting={isBatchDeleting}
         />
       </div>
     </DragDropContext>

--- a/src/components/KanbanColumn.tsx
+++ b/src/components/KanbanColumn.tsx
@@ -11,6 +11,7 @@ interface KanbanColumnProps {
   tasks: Task[];
   onAddTaskClick?: () => void;
   onBatchDeleteClick?: () => void;
+  isBatchDeleting?: boolean;
   nextStep?: 'clone' | 'env' | 'task' | 'complete';
   isAddTaskDialogOpen?: boolean;
   hasApiKey?: boolean;
@@ -22,6 +23,7 @@ export function KanbanColumn({
   tasks,
   onAddTaskClick,
   onBatchDeleteClick,
+  isBatchDeleting = false,
   nextStep,
   isAddTaskDialogOpen = false,
   hasApiKey = false,
@@ -56,9 +58,9 @@ export function KanbanColumn({
           {showBatchDeleteButton && (
             <button
               onClick={onBatchDeleteClick}
-              className="px-3 py-1 rounded bg-red-500 text-white hover:bg-red-600 active:scale-95 transition-transform cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+              className="px-3 py-1 rounded-lg bg-red-700 text-white hover:bg-red-600 active:scale-95 transition-transform cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
               title="Delete Old Tasks"
-              disabled={tasks.length === 0}
+              disabled={tasks.length === 0 || isBatchDeleting}
             >
               <Trash className="w-4 h-4" />
             </button>

--- a/src/hooks/useBatchDelete.ts
+++ b/src/hooks/useBatchDelete.ts
@@ -5,6 +5,7 @@ interface BatchDeleteState {
   batchId: string | null;
   totalCount: number;
   deletedCount: number;
+  errorCount: number;
   isDeleting: boolean;
   isCompleted: boolean;
 }
@@ -15,6 +16,7 @@ export function useBatchDelete() {
     batchId: null,
     totalCount: 0,
     deletedCount: 0,
+    errorCount: 0,
     isDeleting: false,
     isCompleted: false,
   });
@@ -35,10 +37,16 @@ export function useBatchDelete() {
       const result = await response.json();
       const { batchId, totalCount } = result.data;
 
+      // 削除対象が0件の場合は状態を更新しない
+      if (totalCount === 0) {
+        return { batchId, totalCount };
+      }
+
       setState({
         batchId,
         totalCount,
         deletedCount: 0,
+        errorCount: 0,
         isDeleting: true,
         isCompleted: false,
       });
@@ -50,7 +58,7 @@ export function useBatchDelete() {
     }
   }, []);
 
-  // 削除完了イベントを購読
+  // 削除完了イベントと削除エラーイベントを購読
   useEffect(() => {
     if (!eventSource || !state.batchId) return;
 
@@ -62,7 +70,8 @@ export function useBatchDelete() {
         if (data.batchId === state.batchId) {
           setState((prev) => {
             const newDeletedCount = prev.deletedCount + 1;
-            const isCompleted = newDeletedCount >= prev.totalCount;
+            const processedCount = newDeletedCount + prev.errorCount;
+            const isCompleted = processedCount >= prev.totalCount;
 
             return {
               ...prev,
@@ -77,10 +86,36 @@ export function useBatchDelete() {
       }
     };
 
+    const handleTaskDeleteError = (event: MessageEvent) => {
+      try {
+        const data = JSON.parse(event.data);
+
+        // このbatchIdに属するイベントのみカウント
+        if (data.batchId === state.batchId) {
+          setState((prev) => {
+            const newErrorCount = prev.errorCount + 1;
+            const processedCount = prev.deletedCount + newErrorCount;
+            const isCompleted = processedCount >= prev.totalCount;
+
+            return {
+              ...prev,
+              errorCount: newErrorCount,
+              isCompleted,
+              isDeleting: !isCompleted,
+            };
+          });
+        }
+      } catch (error) {
+        console.error('Failed to parse task:delete:error event:', error);
+      }
+    };
+
     eventSource.addEventListener('task:deleted', handleTaskDeleted);
+    eventSource.addEventListener('task:delete:error', handleTaskDeleteError);
 
     return () => {
       eventSource.removeEventListener('task:deleted', handleTaskDeleted);
+      eventSource.removeEventListener('task:delete:error', handleTaskDeleteError);
     };
   }, [eventSource, state.batchId]);
 
@@ -90,6 +125,7 @@ export function useBatchDelete() {
       batchId: null,
       totalCount: 0,
       deletedCount: 0,
+      errorCount: 0,
       isDeleting: false,
       isCompleted: false,
     });

--- a/src/lib/repositories/task.ts
+++ b/src/lib/repositories/task.ts
@@ -8,6 +8,7 @@ export async function getTasks(filter?: {
   status?: Task['status'];
   owner?: string;
   repo?: string;
+  updatedBefore?: Date;
 }): Promise<Task[]> {
   const tasks = await prisma.task.findMany({
     where: {
@@ -15,6 +16,7 @@ export async function getTasks(filter?: {
       ...(filter?.status && { status: filter.status }),
       ...(filter?.owner && { owner: filter.owner }),
       ...(filter?.repo && { repo: filter.repo }),
+      ...(filter?.updatedBefore && { updatedAt: { lt: filter.updatedBefore } }),
     },
     include: {
       tabs: {
@@ -40,7 +42,6 @@ export async function getTasks(filter?: {
     design: task.design ?? undefined,
     procedure: task.procedure ?? undefined,
     pullRequestUrl: task.pullRequestUrl ?? undefined,
-    completedAt: task.completedAt?.toISOString(),
     effort: task.effort ?? undefined,
     order: task.order ?? undefined,
     deletedAt: task.deletedAt?.toISOString(),
@@ -88,7 +89,6 @@ export async function getTask(id: string): Promise<Task | null> {
     design: task.design ?? undefined,
     procedure: task.procedure ?? undefined,
     pullRequestUrl: task.pullRequestUrl ?? undefined,
-    completedAt: task.completedAt?.toISOString(),
     effort: task.effort ?? undefined,
     order: task.order ?? undefined,
     deletedAt: task.deletedAt?.toISOString(),
@@ -127,7 +127,6 @@ export async function createTask(
       design: task.design,
       procedure: task.procedure,
       pullRequestUrl: task.pullRequestUrl,
-      completedAt: task.completedAt ? new Date(task.completedAt) : undefined,
       effort: task.effort,
       order: task.order,
     },
@@ -151,7 +150,6 @@ export async function createTask(
     design: newTask.design ?? undefined,
     procedure: newTask.procedure ?? undefined,
     pullRequestUrl: newTask.pullRequestUrl ?? undefined,
-    completedAt: newTask.completedAt?.toISOString(),
     effort: newTask.effort ?? undefined,
     order: newTask.order ?? undefined,
     deletedAt: newTask.deletedAt?.toISOString(),
@@ -184,9 +182,6 @@ export async function updateTask(
       ...(updates.design !== undefined && { design: updates.design }),
       ...(updates.procedure !== undefined && { procedure: updates.procedure }),
       ...(updates.pullRequestUrl !== undefined && { pullRequestUrl: updates.pullRequestUrl }),
-      ...(updates.completedAt !== undefined && {
-        completedAt: updates.completedAt ? new Date(updates.completedAt) : null,
-      }),
       ...(updates.effort !== undefined && { effort: updates.effort }),
       ...(updates.order !== undefined && { order: updates.order }),
     },
@@ -212,7 +207,6 @@ export async function updateTask(
     design: updatedTask.design ?? undefined,
     procedure: updatedTask.procedure ?? undefined,
     pullRequestUrl: updatedTask.pullRequestUrl ?? undefined,
-    completedAt: updatedTask.completedAt?.toISOString(),
     effort: updatedTask.effort ?? undefined,
     order: updatedTask.order ?? undefined,
     deletedAt: updatedTask.deletedAt?.toISOString(),
@@ -426,6 +420,5 @@ export async function completeTask(taskId: string): Promise<Task | null> {
   // タスクをdoneに遷移
   return updateTask(taskId, {
     status: 'done',
-    completedAt: new Date().toISOString(),
   });
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -20,9 +20,6 @@ export interface Task {
   // Pull Request情報
   pullRequestUrl?: string;
 
-  // 完了日時
-  completedAt?: string; // done時に設定
-
   effort?: number;
   order?: number;
   deletedAt?: string;


### PR DESCRIPTION
- Remove completedAt field from schema (use updatedAt instead)
- Add Prisma-level filtering for status and updatedAt
- Implement concurrent deletion with max 8 parallel workers
- Add error tracking and display in progress notifications
- Fix race condition in concurrent deletion loop