### PR TITLE
Disable Complete Task button when Claude is running

### DIFF
--- a/src/components/TaskActions.tsx
+++ b/src/components/TaskActions.tsx
@@ -374,7 +374,8 @@ PR作成後、タスクをreviewingステータスに更新してください。
               </button>
               <button
                 onClick={handleCompleteTask}
-                className="px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-hover flex items-center gap-2 font-medium text-sm"
+                disabled={isClaudeRunning}
+                className="px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-hover flex items-center gap-2 font-medium text-sm disabled:opacity-50 disabled:cursor-not-allowed"
                 title="Complete task and merge PR"
               >
                 <CheckCircle className="w-4 h-4" />


### PR DESCRIPTION
Claude実行中にComplete Taskボタンもdisabled状態にする修正を実施。
Request Implementation (Fix)ボタンと同様に、Claude実行中は全てのアクションボタンをdisabledにする一貫性を持たせる。