### PR TITLE
fix: Implement hierarchical priority for Claude token environment var…

### DIFF
--- a/src/lib/repositories/environment.ts
+++ b/src/lib/repositories/environment.ts
@@ -16,14 +16,23 @@ export async function getAllEnv(
     orderBy: { createdAt: 'desc' },
   });
 
-  return envVars.map((env) => ({
-    key: env.key,
-    value: env.value,
-    scope: env.scope as 'global' | 'owner' | 'repo',
-    owner: env.owner ?? undefined,
-    repo: env.repo ?? undefined,
-    enabled: env.enabled,
-  }));
+  return envVars.map(
+    (env: {
+      key: string;
+      value: string;
+      scope: string;
+      owner: string | null;
+      repo: string | null;
+      enabled: boolean;
+    }) => ({
+      key: env.key,
+      value: env.value,
+      scope: env.scope as 'global' | 'owner' | 'repo',
+      owner: env.owner ?? undefined,
+      repo: env.repo ?? undefined,
+      enabled: env.enabled,
+    })
+  );
 }
 
 // 環境変数取得（優先順位: repo > owner > global）
@@ -34,11 +43,24 @@ export async function getEnv(
 ): Promise<Record<string, string>> {
   const result: Record<string, string> = {};
 
+  // Claude認証トークンのキー定義
+  const CLAUDE_TOKEN_KEYS = ['ANTHROPIC_API_KEY', 'CLAUDE_CODE_OAUTH_TOKEN'];
+
+  // Helper: Claude認証トークンをクリア
+  const clearClaudeTokens = () => {
+    CLAUDE_TOKEN_KEYS.forEach((key) => delete result[key]);
+  };
+
+  // Helper: 環境変数リストにClaude認証トークンが含まれるか
+  const hasClaudeToken = (envs: Array<{ key: string }>) => {
+    return envs.some((env) => CLAUDE_TOKEN_KEYS.includes(env.key));
+  };
+
   // グローバル変数を先に適用（有効なもののみ）
   const globalEnvs = await prisma.environmentVariable.findMany({
     where: { scope: 'global', enabled: true },
   });
-  globalEnvs.forEach((env) => {
+  globalEnvs.forEach((env: { key: string; value: string }) => {
     result[env.key] = env.value;
   });
 
@@ -47,7 +69,13 @@ export async function getEnv(
     const ownerEnvs = await prisma.environmentVariable.findMany({
       where: { scope: 'owner', owner, enabled: true },
     });
-    ownerEnvs.forEach((env) => {
+
+    // Ownerスコープで新しいClaude認証トークンがあれば、Globalのものをクリア
+    if (hasClaudeToken(ownerEnvs)) {
+      clearClaudeTokens();
+    }
+
+    ownerEnvs.forEach((env: { key: string; value: string }) => {
       result[env.key] = env.value;
     });
   }
@@ -57,14 +85,15 @@ export async function getEnv(
     const repoEnvs = await prisma.environmentVariable.findMany({
       where: { scope: 'repo', owner, repo, enabled: true },
     });
-    repoEnvs.forEach((env) => {
+
+    // Repoスコープで新しいClaude認証トークンがあれば、以前のものをクリア
+    if (hasClaudeToken(repoEnvs)) {
+      clearClaudeTokens();
+    }
+
+    repoEnvs.forEach((env: { key: string; value: string }) => {
       result[env.key] = env.value;
     });
-  }
-
-  // OAuth優先度ロジック: CLAUDE_CODE_OAUTH_TOKENが存在する場合、ANTHROPIC_API_KEYを除外
-  if (result.CLAUDE_CODE_OAUTH_TOKEN && result.ANTHROPIC_API_KEY) {
-    delete result.ANTHROPIC_API_KEY;
   }
 
   return result;


### PR DESCRIPTION
…iables

Modified the getEnv() function to properly handle scope-based priority for Claude authentication tokens (OAuth Token and API Key).

Changes:
- Removed simple OAuth Token priority logic that ignored scope hierarchy
- Added helper functions to detect and clear Claude tokens per scope
- Now correctly prioritizes tokens based on scope: repo > owner > global
- When a more specific scope has a Claude token, previous scope's tokens are cleared

Expected behavior:
- Global: OAuth Token, Owner: API Key → API Key is used
- Global: OAuth Token, Owner: API Key, Repo: OAuth Token → OAuth Token is used
- Only one Claude authentication token is passed to Claude at a time