### PR TITLE
fix: Prevent message scroll position drift in Logs view

### DIFF
--- a/src/components/ExecutionLogsChat.tsx
+++ b/src/components/ExecutionLogsChat.tsx
@@ -101,7 +101,6 @@ const ExecutionLogsChatComponent = forwardRef<ExecutionLogsChatHandle, Execution
       if (!container) return;
 
       const currentScrollHeight = container.scrollHeight;
-      const heightDiff = currentScrollHeight - prevScrollHeightRef.current;
 
       const tabChanged = prevTabIdRef.current !== tabId;
       prevTabIdRef.current = tabId;
@@ -113,10 +112,8 @@ const ExecutionLogsChatComponent = forwardRef<ExecutionLogsChatHandle, Execution
       } else if (isAtBottom) {
         // 最下部にいる状態で新規メッセージ: 即座にスクロール
         logsEndRef.current?.scrollIntoView({ behavior: 'instant' as ScrollBehavior });
-      } else if (heightDiff > 0) {
-        // 最下部以外で高さ増加: スクロール位置を調整して表示位置を維持
-        container.scrollTop += heightDiff;
       }
+      // 最下部以外の場合は何もしない（自然にスクロール位置が維持される）
 
       prevScrollHeightRef.current = currentScrollHeight;
     }, [uiMessages, tabId, isAtBottom]);


### PR DESCRIPTION
## Summary
- Logsで途中のメッセージを見ているときに新しいメッセージが来るとスクロール位置がずれる問題を修正
- 最下部以外では何もしないことで自然にスクロール位置が維持される
- 最下部にいる場合は従来通り自動スクロール

## Changes
- `heightDiff`計算を削除
- `else if (heightDiff > 0)`ブロックを削除（116-119行目）

## Test plan
- [x] Prettier, ESLint, TypeScript型チェックが成功
- [x] 最下部にいる状態で新しいメッセージが来たときに自動スクロールされることを確認
- [x] 途中の位置にいる状態で新しいメッセージが来たときにスクロール位置が維持されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)