### PR TITLE
fix: Repository filter display and persistence issues

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -275,6 +275,9 @@ export default function Home() {
 
       const data = await response.json();
       setRepositories((prev) => [...prev, data.data.repository]);
+
+      // repository一覧を再取得して、TaskDialogなどに最新の状態を反映
+      await loadData();
     } catch (error) {
       console.error('Failed to clone repository:', error);
       throw error;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,6 +5,34 @@ import { Settings, Filter, RefreshCw, FolderDown } from 'lucide-react';
 import { ThemeToggle } from './ThemeToggle';
 import { Combobox } from './ui/Combobox';
 
+const STORAGE_KEY = 'tsunagi-repository-filter';
+
+interface FilterState {
+  repositories: string[];
+  search: string;
+}
+
+// localStorageから読み込み
+const loadFilterState = (): FilterState | null => {
+  if (typeof window === 'undefined') return null;
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    return saved ? JSON.parse(saved) : null;
+  } catch {
+    return null;
+  }
+};
+
+// localStorageに保存
+const saveFilterState = (state: FilterState) => {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // エラーは無視（localStorageが使用できない環境対応）
+  }
+};
+
 interface HeaderProps {
   onCloneClick: () => void;
   onSettingsClick: () => void;
@@ -29,8 +57,14 @@ export function Header({
   onFilterChange,
   isCloneDialogOpen = false,
 }: HeaderProps) {
-  const [repoFilter, setRepoFilter] = useState<string[]>(['all']); // Array of "owner/repo" format or ['all']
-  const [searchQuery, setSearchQuery] = useState<string>('');
+  const [repoFilter, setRepoFilter] = useState<string[]>(() => {
+    const saved = loadFilterState();
+    return saved?.repositories || ['all'];
+  }); // Array of "owner/repo" format or ['all']
+  const [searchQuery, setSearchQuery] = useState<string>(() => {
+    const saved = loadFilterState();
+    return saved?.search || '';
+  });
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const filterRef = useRef<HTMLDivElement>(null);
 
@@ -50,6 +84,26 @@ export function Header({
       document.removeEventListener('mousedown', handleClickOutside);
     };
   }, [isFilterOpen]);
+
+  // 初回マウント時にlocalStorageから読み込んだフィルター状態を適用
+  useEffect(() => {
+    const saved = loadFilterState();
+    if (saved) {
+      // フィルター変更を親コンポーネントに通知
+      if (saved.repositories.includes('all')) {
+        onFilterChange({ owner: '', repo: '', search: saved.search, selectedRepos: ['all'] });
+      } else {
+        const repoList = saved.repositories
+          .map((v) => v.split('/'))
+          .filter((parts) => parts.length === 2);
+        if (repoList.length > 0) {
+          const [owner, repo] = repoList[0];
+          onFilterChange({ owner, repo, search: saved.search, selectedRepos: saved.repositories });
+        }
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Create combined owner/repo list with grouping
   const repoOptions = repositories.map((repository) => ({
@@ -87,6 +141,9 @@ export function Header({
 
     setRepoFilter(values);
 
+    // localStorageに保存
+    saveFilterState({ repositories: values, search: searchQuery });
+
     // If 'all' is selected, show all repositories
     if (values.includes('all')) {
       onFilterChange({ owner: '', repo: '', search: searchQuery, selectedRepos: ['all'] });
@@ -103,6 +160,9 @@ export function Header({
   const handleSearchChange = (value: string) => {
     setSearchQuery(value);
 
+    // localStorageに保存
+    saveFilterState({ repositories: repoFilter, search: value });
+
     if (repoFilter.includes('all') || repoFilter.length === 0) {
       onFilterChange({ owner: '', repo: '', search: value });
     } else {
@@ -117,6 +177,8 @@ export function Header({
   // ボタンハイライト用のスタイル関数
   const handleClearRepoFilter = () => {
     setRepoFilter(['all']);
+    // localStorageに保存
+    saveFilterState({ repositories: ['all'], search: searchQuery });
     onFilterChange({ owner: '', repo: '', search: searchQuery, selectedRepos: ['all'] });
   };
 

--- a/src/components/ui/Combobox.tsx
+++ b/src/components/ui/Combobox.tsx
@@ -4,7 +4,7 @@ import { Combobox as ArkCombobox, useListCollection } from '@ark-ui/react/combob
 import { useFilter } from '@ark-ui/react/locale';
 import { Portal } from '@ark-ui/react/portal';
 import { Check, ChevronsUpDown, X } from 'lucide-react';
-import { useState, useRef, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 
 interface ComboboxOption {
   value: string;
@@ -46,21 +46,43 @@ export function Combobox({
 
   // Manage input value with state
   const [inputValue, setInputValue] = useState('');
-  const isSelectingRef = useRef(false);
 
   const handleValueChange = (details: { value: string[] }) => {
-    isSelectingRef.current = true;
-
+    // onChange を呼び出すだけで、表示の更新は useEffect に任せる
+    // これにより、親コンポーネントで値が正規化された後に正しい表示が適用される
     if (multiple) {
       onChange(details.value);
-      // 複数選択時：選択したlabelsをカンマ区切りで表示
+    } else {
+      const newValue = details.value[0];
+      if (newValue !== undefined) {
+        onChange(newValue);
+      }
+    }
+  };
+
+  const handleInputValueChange = (details: { inputValue: string }) => {
+    // ユーザーが入力している時は、入力値を更新してフィルタリング
+    setInputValue(details.inputValue);
+    filter(details.inputValue);
+    if (allowCustomValue && !multiple) {
+      onChange(details.inputValue);
+    }
+  };
+
+  // Sync input value when value prop changes
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    const normalizedValue = Array.isArray(value) ? value : [value];
+
+    // 複数選択モードの場合、親から渡された値を元に表示を更新
+    if (multiple) {
       // "all"のみの場合は"All Repositories"のみ表示
-      if (details.value.length === 1 && details.value[0] === 'all') {
+      if (normalizedValue.length === 1 && normalizedValue[0] === 'all') {
         const allOption = options.find((opt) => opt.value === 'all');
         setInputValue(allOption?.label || '');
       } else {
         // "all"を除外して、選択されたrepository名のみ表示
-        const labels = details.value
+        const labels = normalizedValue
           .filter((v) => v !== 'all')
           .map((v) => options.find((opt) => opt.value === v)?.label)
           .filter(Boolean)
@@ -68,62 +90,12 @@ export function Combobox({
         setInputValue(labels);
       }
     } else {
-      const newValue = details.value[0];
-      if (newValue !== undefined) {
-        onChange(newValue);
-        // 単一選択時：選択したlabelを表示（入力値をクリア）
-        const label = options.find((opt) => opt.value === newValue)?.label || '';
-        setInputValue(label);
-      }
-    }
-
-    // Reset flag to allow input value updates
-    setTimeout(() => {
-      isSelectingRef.current = false;
-    }, 0);
-  };
-
-  const handleInputValueChange = (details: { inputValue: string }) => {
-    if (!isSelectingRef.current) {
-      setInputValue(details.inputValue);
-    }
-    filter(details.inputValue);
-    if (allowCustomValue && !multiple) {
-      onChange(details.inputValue);
-    }
-  };
-
-  // Sync input value when value prop changes externally (e.g., form reset)
-  useEffect(() => {
-    if (!isSelectingRef.current) {
-      const normalizedValue = Array.isArray(value) ? value : [value];
-
-      // 複数選択モードの場合、handleValueChangeと同じロジックを適用
-      if (multiple) {
-        // "all"のみの場合は"All Repositories"のみ表示
-        if (normalizedValue.length === 1 && normalizedValue[0] === 'all') {
-          const allOption = options.find((opt) => opt.value === 'all');
-          // eslint-disable-next-line react-hooks/set-state-in-effect
-          setInputValue(allOption?.label || '');
-        } else {
-          // "all"を除外して、選択されたrepository名のみ表示
-          const labels = normalizedValue
-            .filter((v) => v !== 'all')
-            .map((v) => options.find((opt) => opt.value === v)?.label)
-            .filter(Boolean)
-            .join(', ');
-          // eslint-disable-next-line react-hooks/set-state-in-effect
-          setInputValue(labels);
-        }
-      } else {
-        // 単一選択モード
-        const labels = normalizedValue
-          .map((v) => options.find((opt) => opt.value === v)?.label)
-          .filter(Boolean)
-          .join(', ');
-        // eslint-disable-next-line react-hooks/set-state-in-effect
-        setInputValue(labels);
-      }
+      // 単一選択モード
+      const labels = normalizedValue
+        .map((v) => options.find((opt) => opt.value === v)?.label)
+        .filter(Boolean)
+        .join(', ');
+      setInputValue(labels);
     }
   }, [value, options, multiple]);
 

--- a/src/components/ui/Combobox.tsx
+++ b/src/components/ui/Combobox.tsx
@@ -54,11 +54,19 @@ export function Combobox({
     if (multiple) {
       onChange(details.value);
       // 複数選択時：選択したlabelsをカンマ区切りで表示
-      const labels = details.value
-        .map((v) => options.find((opt) => opt.value === v)?.label)
-        .filter(Boolean)
-        .join(', ');
-      setInputValue(labels);
+      // "all"のみの場合は"All Repositories"のみ表示
+      if (details.value.length === 1 && details.value[0] === 'all') {
+        const allOption = options.find((opt) => opt.value === 'all');
+        setInputValue(allOption?.label || '');
+      } else {
+        // "all"を除外して、選択されたrepository名のみ表示
+        const labels = details.value
+          .filter((v) => v !== 'all')
+          .map((v) => options.find((opt) => opt.value === v)?.label)
+          .filter(Boolean)
+          .join(', ');
+        setInputValue(labels);
+      }
     } else {
       const newValue = details.value[0];
       if (newValue !== undefined) {

--- a/src/components/ui/Combobox.tsx
+++ b/src/components/ui/Combobox.tsx
@@ -97,14 +97,35 @@ export function Combobox({
   useEffect(() => {
     if (!isSelectingRef.current) {
       const normalizedValue = Array.isArray(value) ? value : [value];
-      const labels = normalizedValue
-        .map((v) => options.find((opt) => opt.value === v)?.label)
-        .filter(Boolean)
-        .join(', ');
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setInputValue(labels);
+
+      // 複数選択モードの場合、handleValueChangeと同じロジックを適用
+      if (multiple) {
+        // "all"のみの場合は"All Repositories"のみ表示
+        if (normalizedValue.length === 1 && normalizedValue[0] === 'all') {
+          const allOption = options.find((opt) => opt.value === 'all');
+          // eslint-disable-next-line react-hooks/set-state-in-effect
+          setInputValue(allOption?.label || '');
+        } else {
+          // "all"を除外して、選択されたrepository名のみ表示
+          const labels = normalizedValue
+            .filter((v) => v !== 'all')
+            .map((v) => options.find((opt) => opt.value === v)?.label)
+            .filter(Boolean)
+            .join(', ');
+          // eslint-disable-next-line react-hooks/set-state-in-effect
+          setInputValue(labels);
+        }
+      } else {
+        // 単一選択モード
+        const labels = normalizedValue
+          .map((v) => options.find((opt) => opt.value === v)?.label)
+          .filter(Boolean)
+          .join(', ');
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        setInputValue(labels);
+      }
     }
-  }, [value, options]);
+  }, [value, options, multiple]);
 
   // Normalize value to array
   const normalizedValue = Array.isArray(value) ? value : [value];


### PR DESCRIPTION
## Summary

- Fix ComboBox to display only selected repository names (removes "All Repositories" when single repo is selected)
- Persist repository filter state to localStorage for cross-page navigation
- Reload repository list after cloning to ensure TaskDialog shows new repositories

## Changes

### 1. ComboBox Display Fix (`src/components/ui/Combobox.tsx`)
- Modified `handleValueChange` to properly handle "all" selection
- When only "all" is selected, displays "All Repositories"
- When specific repos are selected, filters out "all" from display

### 2. localStorage Persistence (`src/components/Header.tsx`)
- Added `loadFilterState` and `saveFilterState` helper functions
- Initialize filter state from localStorage on mount
- Save filter state on every change (repo selection, search query, clear)
- Restore filter state on component mount and notify parent

### 3. Repository List Update (`src/app/page.tsx`)
- Call `loadData()` after successful repository clone
- Ensures TaskDialog receives updated repository list

## Test Plan

- [x] Single repository selection displays only that repository name
- [x] "All Repositories" selection displays "All Repositories"
- [x] Multiple repository selection displays comma-separated names
- [x] Filter state persists across page navigation
- [ ] Cloned repository appears in TaskDialog dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)