### PR TITLE
feat: Use Claude Sonnet 4.6 as default model

### DIFF
--- a/src/lib/claude-client.ts
+++ b/src/lib/claude-client.ts
@@ -126,7 +126,10 @@ export async function executeSession(options: ExecuteOptions): Promise<void> {
     // Execute query
     const queryResult = query({
       prompt: finalPrompt,
-      options: queryOptions,
+      options: {
+        ...queryOptions,
+        model: 'claude-sonnet-4-6',
+      },
     });
 
     // Store the query object for interrupt support


### PR DESCRIPTION
Set model to 'claude-sonnet-4-6' in query options to use the latest Sonnet model. Previously, the SDK defaulted to Sonnet 4.5 (claude-sonnet-4-5-20250929).