### PR TITLE
fix: 音声入力テキストが二重入力されるバグを修正

### DIFF
--- a/src/hooks/useSpeechRecognition.ts
+++ b/src/hooks/useSpeechRecognition.ts
@@ -78,22 +78,38 @@ export const useSpeechRecognition = ({
   const [isListening, setIsListening] = useState(false);
   const recognitionRef = useRef<SpeechRecognition | null>(null);
   const isStartingRef = useRef(false);
+  const isListeningRef = useRef(false);
 
   // 各resultインデックスに対応する位置を管理
   const finalResultsMapRef = useRef<Map<number, ResultPosition>>(new Map());
   const interimResultsMapRef = useRef<Map<number, ResultPosition>>(new Map());
 
-  // ブラウザのSpeechRecognitionサポート判定（初期化時のみ）
-  const SpeechRecognitionAPI =
+  // ブラウザのSpeechRecognitionサポート判定（マウント時のみ評価）
+  const SpeechRecognitionAPIRef = useRef<SpeechRecognitionConstructor | undefined>(
     typeof window !== 'undefined'
       ? window.SpeechRecognition || window.webkitSpeechRecognition
-      : undefined;
+      : undefined
+  );
 
-  const isSupported = !!SpeechRecognitionAPI;
+  const isSupported = !!SpeechRecognitionAPIRef.current;
 
-  // 挿入位置を計算するヘルパー
-  const calculateInsertPosition = useCallback(
-    (resultIndex: number): { line: number; column: number } => {
+  // isListeningをrefでも管理（useEffect内のクロージャで参照するため）
+  useEffect(() => {
+    isListeningRef.current = isListening;
+  }, [isListening]);
+
+  // SpeechRecognition初期化（マウント時のみ）
+  useEffect(() => {
+    const SpeechRecognitionAPI = SpeechRecognitionAPIRef.current;
+    if (!SpeechRecognitionAPI) return;
+
+    const recognition = new SpeechRecognitionAPI();
+    recognition.continuous = true;
+    recognition.interimResults = true;
+    recognition.lang = 'ja-JP';
+
+    // 挿入位置を計算するヘルパー（useEffect内にインライン化）
+    const calculateInsertPosition = (resultIndex: number): { line: number; column: number } => {
       const editor = editorRef.current;
       if (!editor) return { line: 1, column: 1 };
 
@@ -121,186 +137,174 @@ export const useSpeechRecognition = ({
       return position
         ? { line: position.lineNumber, column: position.column }
         : { line: 1, column: 1 };
-    },
-    [editorRef]
-  );
+    };
 
-  // SpeechRecognition初期化
-  useEffect(() => {
-    if (SpeechRecognitionAPI) {
-      const recognition = new SpeechRecognitionAPI();
-      recognition.continuous = true;
-      recognition.interimResults = true;
-      recognition.lang = 'ja-JP';
+    // 認識結果のハンドラー
+    recognition.onresult = (event: SpeechRecognitionEvent) => {
+      const editor = editorRef.current;
+      if (!editor) return;
 
-      // 認識結果のハンドラー
-      recognition.onresult = (event: SpeechRecognitionEvent) => {
-        const editor = editorRef.current;
-        if (!editor) return;
+      // resultIndexからループして処理
+      for (let i = event.resultIndex; i < event.results.length; i++) {
+        const result = event.results[i];
+        const transcript = result[0].transcript;
 
-        // resultIndexからループして処理
-        for (let i = event.resultIndex; i < event.results.length; i++) {
-          const result = event.results[i];
-          const transcript = result[0].transcript;
+        if (result.isFinal) {
+          // 最終結果の処理
+          const interimData = interimResultsMapRef.current.get(i);
 
-          if (result.isFinal) {
-            // 最終結果の処理
-            const interimData = interimResultsMapRef.current.get(i);
+          if (interimData) {
+            // 中間結果を最終結果に置き換え
+            const range = {
+              startLineNumber: interimData.position.line,
+              startColumn: interimData.position.column,
+              endLineNumber: interimData.position.line,
+              endColumn: interimData.position.column + interimData.length,
+            };
 
-            if (interimData) {
-              // 中間結果を最終結果に置き換え
-              const range = {
-                startLineNumber: interimData.position.line,
-                startColumn: interimData.position.column,
-                endLineNumber: interimData.position.line,
-                endColumn: interimData.position.column + interimData.length,
-              };
+            editor.executeEdits('speech-recognition', [
+              {
+                range,
+                text: transcript,
+              },
+            ]);
 
-              editor.executeEdits('speech-recognition', [
-                {
-                  range,
-                  text: transcript,
-                },
-              ]);
+            // finalResultsMapに登録
+            finalResultsMapRef.current.set(i, {
+              position: interimData.position,
+              length: transcript.length,
+            });
 
-              // finalResultsMapに登録
-              finalResultsMapRef.current.set(i, {
-                position: interimData.position,
-                length: transcript.length,
-              });
-
-              // interimResultsMapから削除
-              interimResultsMapRef.current.delete(i);
-            } else {
-              // 中間結果がない場合（最初から最終結果）
-              const insertPosition = calculateInsertPosition(i);
-
-              const range = {
-                startLineNumber: insertPosition.line,
-                startColumn: insertPosition.column,
-                endLineNumber: insertPosition.line,
-                endColumn: insertPosition.column,
-              };
-
-              editor.executeEdits('speech-recognition', [
-                {
-                  range,
-                  text: transcript,
-                },
-              ]);
-
-              finalResultsMapRef.current.set(i, {
-                position: insertPosition,
-                length: transcript.length,
-              });
-            }
-
-            // カーソルを最終結果の末尾に移動
-            const finalData = finalResultsMapRef.current.get(i);
-            if (finalData) {
-              editor.setPosition({
-                lineNumber: finalData.position.line,
-                column: finalData.position.column + finalData.length,
-              });
-            }
+            // interimResultsMapから削除
+            interimResultsMapRef.current.delete(i);
           } else {
-            // 中間結果の処理
-            const existingInterim = interimResultsMapRef.current.get(i);
+            // 中間結果がない場合（最初から最終結果）
+            const insertPosition = calculateInsertPosition(i);
 
-            if (existingInterim) {
-              // 既存の中間結果を上書き
-              const range = {
-                startLineNumber: existingInterim.position.line,
-                startColumn: existingInterim.position.column,
-                endLineNumber: existingInterim.position.line,
-                endColumn: existingInterim.position.column + existingInterim.length,
-              };
+            const range = {
+              startLineNumber: insertPosition.line,
+              startColumn: insertPosition.column,
+              endLineNumber: insertPosition.line,
+              endColumn: insertPosition.column,
+            };
 
-              editor.executeEdits('speech-recognition', [
-                {
-                  range,
-                  text: transcript,
-                },
-              ]);
+            editor.executeEdits('speech-recognition', [
+              {
+                range,
+                text: transcript,
+              },
+            ]);
 
-              interimResultsMapRef.current.set(i, {
-                position: existingInterim.position,
-                length: transcript.length,
-              });
-            } else {
-              // 新しい中間結果
-              const insertPosition = calculateInsertPosition(i);
+            finalResultsMapRef.current.set(i, {
+              position: insertPosition,
+              length: transcript.length,
+            });
+          }
 
-              const range = {
-                startLineNumber: insertPosition.line,
-                startColumn: insertPosition.column,
-                endLineNumber: insertPosition.line,
-                endColumn: insertPosition.column,
-              };
+          // カーソルを最終結果の末尾に移動
+          const finalData = finalResultsMapRef.current.get(i);
+          if (finalData) {
+            editor.setPosition({
+              lineNumber: finalData.position.line,
+              column: finalData.position.column + finalData.length,
+            });
+          }
+        } else {
+          // 中間結果の処理
+          const existingInterim = interimResultsMapRef.current.get(i);
 
-              editor.executeEdits('speech-recognition', [
-                {
-                  range,
-                  text: transcript,
-                },
-              ]);
+          if (existingInterim) {
+            // 既存の中間結果を上書き
+            const range = {
+              startLineNumber: existingInterim.position.line,
+              startColumn: existingInterim.position.column,
+              endLineNumber: existingInterim.position.line,
+              endColumn: existingInterim.position.column + existingInterim.length,
+            };
 
-              interimResultsMapRef.current.set(i, {
-                position: insertPosition,
-                length: transcript.length,
-              });
-            }
+            editor.executeEdits('speech-recognition', [
+              {
+                range,
+                text: transcript,
+              },
+            ]);
 
-            // カーソルを中間結果の末尾に移動
-            const interimData = interimResultsMapRef.current.get(i);
-            if (interimData) {
-              editor.setPosition({
-                lineNumber: interimData.position.line,
-                column: interimData.position.column + interimData.length,
-              });
-            }
+            interimResultsMapRef.current.set(i, {
+              position: existingInterim.position,
+              length: transcript.length,
+            });
+          } else {
+            // 新しい中間結果
+            const insertPosition = calculateInsertPosition(i);
+
+            const range = {
+              startLineNumber: insertPosition.line,
+              startColumn: insertPosition.column,
+              endLineNumber: insertPosition.line,
+              endColumn: insertPosition.column,
+            };
+
+            editor.executeEdits('speech-recognition', [
+              {
+                range,
+                text: transcript,
+              },
+            ]);
+
+            interimResultsMapRef.current.set(i, {
+              position: insertPosition,
+              length: transcript.length,
+            });
+          }
+
+          // カーソルを中間結果の末尾に移動
+          const interimData = interimResultsMapRef.current.get(i);
+          if (interimData) {
+            editor.setPosition({
+              lineNumber: interimData.position.line,
+              column: interimData.position.column + interimData.length,
+            });
           }
         }
+      }
 
-        editor.focus();
-      };
+      editor.focus();
+    };
 
-      // エラーハンドラー
-      recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
-        console.error('Speech recognition error:', event.error);
-        isStartingRef.current = false;
-        if (event.error === 'no-speech' || event.error === 'aborted') {
-          // ユーザーが話していない、または中断された場合は自動的に停止
-          setIsListening(false);
-        } else if (event.error === 'not-allowed') {
-          // マイクの許可が拒否された
-          console.error('Microphone permission denied');
-          setIsListening(false);
-        }
-      };
-
-      // 認識終了ハンドラー
-      recognition.onend = () => {
+    // エラーハンドラー
+    recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
+      console.error('Speech recognition error:', event.error);
+      isStartingRef.current = false;
+      if (event.error === 'no-speech' || event.error === 'aborted') {
+        // ユーザーが話していない、または中断された場合は自動的に停止
         setIsListening(false);
-        isStartingRef.current = false;
-        // Mapをクリア
-        finalResultsMapRef.current.clear();
-        interimResultsMapRef.current.clear();
-      };
-
-      recognitionRef.current = recognition;
-    }
-
-    return () => {
-      if (recognitionRef.current) {
-        recognitionRef.current.stop();
+      } else if (event.error === 'not-allowed') {
+        // マイクの許可が拒否された
+        console.error('Microphone permission denied');
+        setIsListening(false);
       }
     };
-  }, [editorRef, SpeechRecognitionAPI, calculateInsertPosition]);
+
+    // 認識終了ハンドラー
+    recognition.onend = () => {
+      setIsListening(false);
+      isStartingRef.current = false;
+      // Mapをクリア
+      finalResultsMapRef.current.clear();
+      interimResultsMapRef.current.clear();
+    };
+
+    recognitionRef.current = recognition;
+
+    return () => {
+      recognition.stop();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const startListening = useCallback(() => {
     const recognition = recognitionRef.current;
-    if (!recognition || isListening || isStartingRef.current) return;
+    if (!recognition || isListeningRef.current || isStartingRef.current) return;
 
     try {
       isStartingRef.current = true;
@@ -315,7 +319,7 @@ export const useSpeechRecognition = ({
         try {
           recognition.stop();
           setTimeout(() => {
-            if (recognitionRef.current && !isListening) {
+            if (recognitionRef.current && !isListeningRef.current) {
               try {
                 isStartingRef.current = true;
                 recognitionRef.current.start();
@@ -331,11 +335,11 @@ export const useSpeechRecognition = ({
         }
       }
     }
-  }, [isListening]);
+  }, []);
 
   const stopListening = useCallback(() => {
     const recognition = recognitionRef.current;
-    if (!recognition || !isListening) return;
+    if (!recognition || !isListeningRef.current) return;
 
     try {
       recognition.stop();
@@ -345,7 +349,7 @@ export const useSpeechRecognition = ({
       setIsListening(false);
       isStartingRef.current = false;
     }
-  }, [isListening]);
+  }, []);
 
   return {
     isListening,

--- a/src/hooks/useSpeechRecognition.ts
+++ b/src/hooks/useSpeechRecognition.ts
@@ -140,6 +140,11 @@ export const useSpeechRecognition = ({
         : { line: 1, column: 1 };
     };
 
+    // 認識開始ハンドラー（デバッグ用）
+    (recognition as SpeechRecognition & { onstart: (() => void) | null }).onstart = () => {
+      console.log('[SR] onstart fired - recognition is active');
+    };
+
     // 認識結果のハンドラー
     recognition.onresult = (event: SpeechRecognitionEvent) => {
       console.log('[SR] onresult fired, resultIndex:', event.resultIndex, 'results.length:', event.results.length);
@@ -292,17 +297,22 @@ export const useSpeechRecognition = ({
       console.log('[SR] onend fired, isListeningRef:', isListeningRef.current);
       isStartingRef.current = false;
 
-      // isListening が true のままなら、ユーザーが意図的に停止していない
-      // → continuous モードで no-speech 等により自動終了した場合は再起動する
       if (isListeningRef.current) {
-        try {
-          recognition.start();
-        } catch {
-          // 再起動に失敗した場合は停止扱いにする
-          setIsListening(false);
-          finalResultsMapRef.current.clear();
-          interimResultsMapRef.current.clear();
-        }
+        // ユーザーが意図的に停止していない場合、少し待って再起動
+        // 即時再起動するとブラウザが no-speech ループに入るため遅延させる
+        setTimeout(() => {
+          if (isListeningRef.current && recognitionRef.current) {
+            console.log('[SR] restarting recognition...');
+            try {
+              recognitionRef.current.start();
+            } catch {
+              isListeningRef.current = false;
+              setIsListening(false);
+              finalResultsMapRef.current.clear();
+              interimResultsMapRef.current.clear();
+            }
+          }
+        }, 300);
         return;
       }
 

--- a/src/hooks/useSpeechRecognition.ts
+++ b/src/hooks/useSpeechRecognition.ts
@@ -67,11 +67,6 @@ interface UseSpeechRecognitionReturn {
   stopListening: () => void;
 }
 
-interface ResultPosition {
-  position: { line: number; column: number };
-  length: number;
-}
-
 export const useSpeechRecognition = ({
   editorRef,
 }: UseSpeechRecognitionProps): UseSpeechRecognitionReturn => {
@@ -79,9 +74,11 @@ export const useSpeechRecognition = ({
   const recognitionRef = useRef<SpeechRecognition | null>(null);
   const isStartingRef = useRef(false);
 
-  // 各resultインデックスに対応する位置を管理
-  const finalResultsMapRef = useRef<Map<number, ResultPosition>>(new Map());
-  const interimResultsMapRef = useRef<Map<number, ResultPosition>>(new Map());
+  // 現在 editor に書き込まれている interim テキストとその開始位置
+  // startListening 時にカーソル位置で初期化し、onresult で更新する
+  const interimTextRef = useRef('');
+  const interimStartLineRef = useRef(1);
+  const interimStartColumnRef = useRef(1);
 
   // ブラウザのSpeechRecognitionサポート判定（初期化時のみ）
   const SpeechRecognitionAPI =
@@ -91,219 +88,89 @@ export const useSpeechRecognition = ({
 
   const isSupported = !!SpeechRecognitionAPI;
 
-  // 挿入位置を計算するヘルパー
-  const calculateInsertPosition = useCallback(
-    (resultIndex: number): { line: number; column: number } => {
-      const editor = editorRef.current;
-      if (!editor) return { line: 1, column: 1 };
-
-      // 前の結果（最終 or 中間）の末尾位置を取得
-      for (let i = resultIndex - 1; i >= 0; i--) {
-        const finalData = finalResultsMapRef.current.get(i);
-        if (finalData) {
-          return {
-            line: finalData.position.line,
-            column: finalData.position.column + finalData.length,
-          };
-        }
-
-        const interimData = interimResultsMapRef.current.get(i);
-        if (interimData) {
-          return {
-            line: interimData.position.line,
-            column: interimData.position.column + interimData.length,
-          };
-        }
-      }
-
-      // 前の結果がない場合、現在のカーソル位置
-      const position = editor.getPosition();
-      return position
-        ? { line: position.lineNumber, column: position.column }
-        : { line: 1, column: 1 };
-    },
-    [editorRef]
-  );
-
   // SpeechRecognition初期化
   useEffect(() => {
-    if (SpeechRecognitionAPI) {
-      const recognition = new SpeechRecognitionAPI();
-      recognition.continuous = true;
-      recognition.interimResults = true;
-      recognition.lang = 'ja-JP';
+    if (!SpeechRecognitionAPI) return;
 
-      // 認識結果のハンドラー
-      recognition.onresult = (event: SpeechRecognitionEvent) => {
-        const editor = editorRef.current;
-        if (!editor) return;
+    const recognition = new SpeechRecognitionAPI();
+    recognition.continuous = true;
+    recognition.interimResults = true;
+    recognition.lang = 'ja-JP';
 
-        // resultIndexからループして処理
-        for (let i = event.resultIndex; i < event.results.length; i++) {
-          const result = event.results[i];
-          const transcript = result[0].transcript;
-          console.log(`[SR] i=${i} isFinal=${result.isFinal} transcript="${transcript}" interimMap=${JSON.stringify([...interimResultsMapRef.current.entries()])} finalMap=${JSON.stringify([...finalResultsMapRef.current.entries()])}`);
+    recognition.onresult = (event: SpeechRecognitionEvent) => {
+      const editor = editorRef.current;
+      if (!editor) return;
 
-          if (result.isFinal) {
-            // 最終結果の処理
-            const interimData = interimResultsMapRef.current.get(i);
+      for (let i = event.resultIndex; i < event.results.length; i++) {
+        const result = event.results[i];
+        const transcript = result[0].transcript;
+        const interimText = interimTextRef.current;
+        const startLine = interimStartLineRef.current;
+        const startColumn = interimStartColumnRef.current;
 
-            if (interimData) {
-              // 中間結果を最終結果に置き換え
-              const range = {
-                startLineNumber: interimData.position.line,
-                startColumn: interimData.position.column,
-                endLineNumber: interimData.position.line,
-                endColumn: interimData.position.column + interimData.length,
-              };
+        // 現在の interim 範囲を transcript で置換（interim/final 共通）
+        editor.executeEdits('speech-recognition', [
+          {
+            range: {
+              startLineNumber: startLine,
+              startColumn: startColumn,
+              endLineNumber: startLine,
+              endColumn: startColumn + interimText.length,
+            },
+            text: transcript,
+          },
+        ]);
 
-              editor.executeEdits('speech-recognition', [
-                {
-                  range,
-                  text: transcript,
-                },
-              ]);
-
-              // finalResultsMapに登録
-              finalResultsMapRef.current.set(i, {
-                position: interimData.position,
-                length: transcript.length,
-              });
-
-              // interimResultsMapから削除
-              interimResultsMapRef.current.delete(i);
-            } else {
-              // 中間結果がない場合（最初から最終結果）
-              const insertPosition = calculateInsertPosition(i);
-
-              const range = {
-                startLineNumber: insertPosition.line,
-                startColumn: insertPosition.column,
-                endLineNumber: insertPosition.line,
-                endColumn: insertPosition.column,
-              };
-
-              editor.executeEdits('speech-recognition', [
-                {
-                  range,
-                  text: transcript,
-                },
-              ]);
-
-              finalResultsMapRef.current.set(i, {
-                position: insertPosition,
-                length: transcript.length,
-              });
-            }
-
-            // カーソルを最終結果の末尾に移動
-            const finalData = finalResultsMapRef.current.get(i);
-            if (finalData) {
-              editor.setPosition({
-                lineNumber: finalData.position.line,
-                column: finalData.position.column + finalData.length,
-              });
-            }
-          } else {
-            // 中間結果の処理
-            const existingInterim = interimResultsMapRef.current.get(i);
-
-            if (existingInterim) {
-              // 既存の中間結果を上書き
-              const range = {
-                startLineNumber: existingInterim.position.line,
-                startColumn: existingInterim.position.column,
-                endLineNumber: existingInterim.position.line,
-                endColumn: existingInterim.position.column + existingInterim.length,
-              };
-
-              editor.executeEdits('speech-recognition', [
-                {
-                  range,
-                  text: transcript,
-                },
-              ]);
-
-              interimResultsMapRef.current.set(i, {
-                position: existingInterim.position,
-                length: transcript.length,
-              });
-            } else {
-              // 新しい中間結果
-              const insertPosition = calculateInsertPosition(i);
-
-              const range = {
-                startLineNumber: insertPosition.line,
-                startColumn: insertPosition.column,
-                endLineNumber: insertPosition.line,
-                endColumn: insertPosition.column,
-              };
-
-              editor.executeEdits('speech-recognition', [
-                {
-                  range,
-                  text: transcript,
-                },
-              ]);
-
-              interimResultsMapRef.current.set(i, {
-                position: insertPosition,
-                length: transcript.length,
-              });
-            }
-
-            // カーソルを中間結果の末尾に移動
-            const interimData = interimResultsMapRef.current.get(i);
-            if (interimData) {
-              editor.setPosition({
-                lineNumber: interimData.position.line,
-                column: interimData.position.column + interimData.length,
-              });
-            }
-          }
+        if (result.isFinal) {
+          // 次のフレーズ開始位置をこの final の末尾に進めて interim をリセット
+          interimStartColumnRef.current = startColumn + transcript.length;
+          interimTextRef.current = '';
+        } else {
+          // interim テキストを更新
+          interimTextRef.current = transcript;
         }
 
-        editor.focus();
-      };
+        // カーソルを末尾に移動
+        editor.setPosition({
+          lineNumber: interimStartLineRef.current,
+          column: interimStartColumnRef.current + interimTextRef.current.length,
+        });
+      }
 
-      // エラーハンドラー
-      recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
-        console.error('Speech recognition error:', event.error);
-        isStartingRef.current = false;
-        if (event.error === 'no-speech' || event.error === 'aborted') {
-          // ユーザーが話していない、または中断された場合は自動的に停止
-          setIsListening(false);
-        } else if (event.error === 'not-allowed') {
-          // マイクの許可が拒否された
-          console.error('Microphone permission denied');
-          setIsListening(false);
-        }
-      };
+      editor.focus();
+    };
 
-      // 認識終了ハンドラー
-      recognition.onend = () => {
-        setIsListening(false);
-        isStartingRef.current = false;
-        // Mapをクリア
-        finalResultsMapRef.current.clear();
-        interimResultsMapRef.current.clear();
-      };
+    recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
+      if (event.error === 'no-speech') return;
+      console.error('Speech recognition error:', event.error);
+      isStartingRef.current = false;
+      setIsListening(false);
+    };
 
-      recognitionRef.current = recognition;
-    }
+    recognition.onend = () => {
+      setIsListening(false);
+      isStartingRef.current = false;
+    };
+
+    recognitionRef.current = recognition;
 
     return () => {
       if (recognitionRef.current) {
         recognitionRef.current.stop();
       }
-      finalResultsMapRef.current.clear();
-      interimResultsMapRef.current.clear();
     };
-  }, [editorRef, SpeechRecognitionAPI, calculateInsertPosition]);
+  }, [editorRef, SpeechRecognitionAPI]);
 
   const startListening = useCallback(() => {
     const recognition = recognitionRef.current;
+    const editor = editorRef.current;
     if (!recognition || isListening || isStartingRef.current) return;
+
+    // 音声入力開始時のカーソル位置を記録
+    const position = editor?.getPosition();
+    interimStartLineRef.current = position?.lineNumber ?? 1;
+    interimStartColumnRef.current = position?.column ?? 1;
+    interimTextRef.current = '';
 
     try {
       isStartingRef.current = true;
@@ -313,7 +180,6 @@ export const useSpeechRecognition = ({
       console.error('Failed to start speech recognition:', error);
       isStartingRef.current = false;
 
-      // already started エラーの場合、一度停止してから再開
       if (error instanceof Error && error.message.includes('already started')) {
         try {
           recognition.stop();
@@ -334,7 +200,7 @@ export const useSpeechRecognition = ({
         }
       }
     }
-  }, [isListening]);
+  }, [isListening, editorRef]);
 
   const stopListening = useCallback(() => {
     const recognition = recognitionRef.current;
@@ -342,7 +208,6 @@ export const useSpeechRecognition = ({
 
     try {
       recognition.stop();
-      // onend で setIsListening(false) が呼ばれるのを待つ
     } catch (error) {
       console.error('Failed to stop speech recognition:', error);
       setIsListening(false);

--- a/src/hooks/useSpeechRecognition.ts
+++ b/src/hooks/useSpeechRecognition.ts
@@ -295,7 +295,7 @@ export const useSpeechRecognition = ({
     }
 
     return () => {
-      console.log('[SR] cleanup instance:', recognition);
+      console.log('[SR] cleanup, recognitionRef:', recognitionRef.current);
       if (recognitionRef.current) {
         recognitionRef.current.stop();
       }

--- a/src/hooks/useSpeechRecognition.ts
+++ b/src/hooks/useSpeechRecognition.ts
@@ -292,15 +292,8 @@ export const useSpeechRecognition = ({
     }
 
     return () => {
-      const r = recognitionRef.current;
-      if (r) {
-        // ハンドラーを無効化してから abort することで、
-        // このインスタンスの結果が editor に書き込まれるのを防ぐ
-        r.onresult = null;
-        r.onend = null;
-        r.onerror = null;
-        r.abort();
-        recognitionRef.current = null;
+      if (recognitionRef.current) {
+        recognitionRef.current.stop();
       }
     };
   }, [editorRef, SpeechRecognitionAPI, calculateInsertPosition]);

--- a/src/hooks/useSpeechRecognition.ts
+++ b/src/hooks/useSpeechRecognition.ts
@@ -339,6 +339,7 @@ export const useSpeechRecognition = ({
       recognition.abort();
       recognitionRef.current = null;
       // 状態もリセット（onend が呼ばれないためここでリセット）
+      isListeningRef.current = false;
       setIsListening(false);
       isStartingRef.current = false;
       finalResultsMap.clear();

--- a/src/hooks/useSpeechRecognition.ts
+++ b/src/hooks/useSpeechRecognition.ts
@@ -145,8 +145,6 @@ export const useSpeechRecognition = ({
 
     // 認識結果のハンドラー
     recognition.onresult = (event: SpeechRecognitionEvent) => {
-      // 古いインスタンスのイベントは無視
-      if (recognitionRef.current !== recognition) return;
       const editor = editorRef.current;
       if (!editor) return;
 
@@ -279,8 +277,6 @@ export const useSpeechRecognition = ({
 
     // エラーハンドラー
     recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
-      // 古いインスタンスのイベントは無視
-      if (recognitionRef.current !== recognition) return;
       console.error('Speech recognition error:', event.error);
       isStartingRef.current = false;
       if (event.error === 'no-speech' || event.error === 'aborted') {
@@ -295,8 +291,6 @@ export const useSpeechRecognition = ({
 
     // 認識終了ハンドラー
     recognition.onend = () => {
-      // 古いインスタンスのイベントは無視
-      if (recognitionRef.current !== recognition) return;
       setIsListening(false);
       isStartingRef.current = false;
       // Mapをクリア
@@ -306,12 +300,23 @@ export const useSpeechRecognition = ({
 
     recognitionRef.current = recognition;
 
+    // クリーンアップ時に ref.current を直接参照しないよう変数にコピー
+    const finalResultsMap = finalResultsMapRef.current;
+    const interimResultsMap = interimResultsMapRef.current;
+
     return () => {
-      // リスニング中の場合のみ停止（未起動の recognition に stop() を呼ぶと onend が発火し状態が壊れるため）
-      if (isListeningRef.current) {
-        recognition.stop();
-      }
+      // ハンドラーを先に無効化してから abort することで、
+      // abort 後に発火する可能性のある onend/onerror の副作用を防ぐ
+      recognition.onresult = null;
+      recognition.onerror = null;
+      recognition.onend = null;
+      recognition.abort();
       recognitionRef.current = null;
+      // 状態もリセット（onend が呼ばれないためここでリセット）
+      setIsListening(false);
+      isStartingRef.current = false;
+      finalResultsMap.clear();
+      interimResultsMap.clear();
     };
   }, [editorRef]);
 

--- a/src/hooks/useSpeechRecognition.ts
+++ b/src/hooks/useSpeechRecognition.ts
@@ -129,12 +129,14 @@ export const useSpeechRecognition = ({
   useEffect(() => {
     if (SpeechRecognitionAPI) {
       const recognition = new SpeechRecognitionAPI();
+      console.log('[SR] new recognition instance:', recognition);
       recognition.continuous = true;
       recognition.interimResults = true;
       recognition.lang = 'ja-JP';
 
       // 認識結果のハンドラー
       recognition.onresult = (event: SpeechRecognitionEvent) => {
+        console.log('[SR] onresult instance:', recognition, 'recognitionRef:', recognitionRef.current);
         const editor = editorRef.current;
         if (!editor) return;
 
@@ -142,6 +144,7 @@ export const useSpeechRecognition = ({
         for (let i = event.resultIndex; i < event.results.length; i++) {
           const result = event.results[i];
           const transcript = result[0].transcript;
+          console.log(`[SR] result[${i}] isFinal:${result.isFinal} transcript:"${transcript}"`);
 
           if (result.isFinal) {
             // 最終結果の処理
@@ -292,6 +295,7 @@ export const useSpeechRecognition = ({
     }
 
     return () => {
+      console.log('[SR] cleanup instance:', recognition);
       if (recognitionRef.current) {
         recognitionRef.current.stop();
       }

--- a/src/hooks/useSpeechRecognition.ts
+++ b/src/hooks/useSpeechRecognition.ts
@@ -97,17 +97,14 @@ export const useSpeechRecognition = ({
     typeof window !== 'undefined' && !!(window.SpeechRecognition ?? window.webkitSpeechRecognition)
   );
 
-  // isListeningをrefでも管理（useEffect内のクロージャで参照するため）
-  useEffect(() => {
-    isListeningRef.current = isListening;
-  }, [isListening]);
-
   // SpeechRecognition初期化（マウント時のみ）
   useEffect(() => {
     const SpeechRecognitionAPI = SpeechRecognitionAPIRef.current;
+    console.log('[SR] useEffect run, SpeechRecognitionAPI:', !!SpeechRecognitionAPI);
     if (!SpeechRecognitionAPI) return;
 
     const recognition = new SpeechRecognitionAPI();
+    console.log('[SR] recognition instance created:', recognition);
     recognition.continuous = true;
     recognition.interimResults = true;
     recognition.lang = 'ja-JP';
@@ -145,7 +142,9 @@ export const useSpeechRecognition = ({
 
     // 認識結果のハンドラー
     recognition.onresult = (event: SpeechRecognitionEvent) => {
+      console.log('[SR] onresult fired, resultIndex:', event.resultIndex, 'results.length:', event.results.length);
       const editor = editorRef.current;
+      console.log('[SR] editor:', !!editor);
       if (!editor) return;
 
       // resultIndexからループして処理
@@ -277,6 +276,7 @@ export const useSpeechRecognition = ({
 
     // エラーハンドラー
     recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
+      console.log('[SR] onerror:', event.error);
       if (event.error === 'no-speech') {
         // continuous モードでは一時的に音声が検出されなかっただけ。セッション継続
         return;
@@ -289,6 +289,7 @@ export const useSpeechRecognition = ({
 
     // 認識終了ハンドラー
     recognition.onend = () => {
+      console.log('[SR] onend fired, isListeningRef:', isListeningRef.current);
       isStartingRef.current = false;
 
       // isListening が true のままなら、ユーザーが意図的に停止していない
@@ -312,12 +313,14 @@ export const useSpeechRecognition = ({
     };
 
     recognitionRef.current = recognition;
+    console.log('[SR] recognitionRef set, instance id:', recognition);
 
     // クリーンアップ時に ref.current を直接参照しないよう変数にコピー
     const finalResultsMap = finalResultsMapRef.current;
     const interimResultsMap = interimResultsMapRef.current;
 
     return () => {
+      console.log('[SR] cleanup called');
       // ハンドラーを先に無効化してから abort することで、
       // abort 後に発火する可能性のある onend/onerror の副作用を防ぐ
       recognition.onresult = null;
@@ -335,15 +338,19 @@ export const useSpeechRecognition = ({
 
   const startListening = useCallback(() => {
     const recognition = recognitionRef.current;
+    console.log('[SR] startListening called, recognition:', !!recognition, 'isListening:', isListeningRef.current, 'isStarting:', isStartingRef.current);
     if (!recognition || isListeningRef.current || isStartingRef.current) return;
 
     try {
       isStartingRef.current = true;
+      isListeningRef.current = true; // setIsListening より先に同期的にフラグを立てる
       recognition.start();
       setIsListening(true);
+      console.log('[SR] recognition.start() called');
     } catch (error) {
       console.error('Failed to start speech recognition:', error);
       isStartingRef.current = false;
+      isListeningRef.current = false;
 
       // already started エラーの場合、一度停止してから再開
       if (error instanceof Error && error.message.includes('already started')) {

--- a/src/hooks/useSpeechRecognition.ts
+++ b/src/hooks/useSpeechRecognition.ts
@@ -277,16 +277,14 @@ export const useSpeechRecognition = ({
 
     // エラーハンドラー
     recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
+      if (event.error === 'no-speech') {
+        // continuous モードでは一時的に音声が検出されなかっただけ。セッション継続
+        return;
+      }
       console.error('Speech recognition error:', event.error);
       isStartingRef.current = false;
-      if (event.error === 'no-speech' || event.error === 'aborted') {
-        // ユーザーが話していない、または中断された場合は自動的に停止
-        setIsListening(false);
-      } else if (event.error === 'not-allowed') {
-        // マイクの許可が拒否された
-        console.error('Microphone permission denied');
-        setIsListening(false);
-      }
+      // not-allowed: マイク許可拒否、audio-capture: マイクなし など致命的なエラーは停止
+      setIsListening(false);
     };
 
     // 認識終了ハンドラー

--- a/src/hooks/useSpeechRecognition.ts
+++ b/src/hooks/useSpeechRecognition.ts
@@ -67,6 +67,13 @@ interface UseSpeechRecognitionReturn {
   stopListening: () => void;
 }
 
+// 前回と今回のテキストの共通プレフィックス長を返す
+const commonPrefixLength = (a: string, b: string): number => {
+  let i = 0;
+  while (i < a.length && i < b.length && a[i] === b[i]) i++;
+  return i;
+};
+
 export const useSpeechRecognition = ({
   editorRef,
 }: UseSpeechRecognitionProps): UseSpeechRecognitionReturn => {
@@ -74,11 +81,10 @@ export const useSpeechRecognition = ({
   const recognitionRef = useRef<SpeechRecognition | null>(null);
   const isStartingRef = useRef(false);
 
-  // 現在 editor に書き込まれている interim テキストとその開始位置
-  // startListening 時にカーソル位置で初期化し、onresult で更新する
+  // 現在 editor に書き込まれている interim テキストとその開始オフセット
+  // line/column ではなくモデルの文字オフセットで管理することで変換の誤差を排除する
   const interimTextRef = useRef('');
-  const interimStartLineRef = useRef(1);
-  const interimStartColumnRef = useRef(1);
+  const interimStartOffsetRef = useRef(0);
 
   // ブラウザのSpeechRecognitionサポート判定（初期化時のみ）
   const SpeechRecognitionAPI =
@@ -98,49 +104,68 @@ export const useSpeechRecognition = ({
     recognition.lang = 'ja-JP';
 
     recognition.onresult = (event: SpeechRecognitionEvent) => {
-      const editor = editorRef.current;
-      if (!editor) return;
+      const editorInstance = editorRef.current;
+      if (!editorInstance) return;
+
+      const model = editorInstance.getModel();
+      if (!model) return;
 
       for (let i = event.resultIndex; i < event.results.length; i++) {
         const result = event.results[i];
-        const transcript = result[0].transcript;
-        const interimText = interimTextRef.current;
-        const startLine = interimStartLineRef.current;
-        const startColumn = interimStartColumnRef.current;
+        // Web Speech API は transcript の先頭に半角スペースを付けることがあるため除去する
+        const transcript = result[0].transcript.trimStart();
+        const prevInterimText = interimTextRef.current;
 
-        // 現在の interim 範囲を transcript で置換（interim/final 共通）
-        editor.executeEdits('speech-recognition', [
+        // フレーズ先頭（prevInterimText が空）のとき、isFinal 後にユーザーがカーソルを
+        // 移動していた場合に追従する。エディタの実際のカーソル位置を開始位置として採用する。
+        if (prevInterimText === '') {
+          const cursorPos = editorInstance.getPosition();
+          if (cursorPos) {
+            interimStartOffsetRef.current = model.getOffsetAt(cursorPos);
+          }
+        }
+
+        const startOffset = interimStartOffsetRef.current;
+
+        // 前回との共通プレフィックスを求め、差分部分だけを editor に適用する
+        // これによりカーソルは常に変更箇所の末尾（前進方向）に留まる
+        const prefixLen = commonPrefixLength(prevInterimText, transcript);
+        const deleteFrom = startOffset + prefixLen;
+        // prevInterimText が '' の場合は deleteTo == deleteFrom になり挿入のみになる
+        const deleteTo = startOffset + prevInterimText.length;
+        const insertText = transcript.slice(prefixLen);
+
+        const deleteFromPos = model.getPositionAt(deleteFrom);
+        const deleteToPos = model.getPositionAt(deleteTo);
+
+        editorInstance.executeEdits('speech-recognition', [
           {
             range: {
-              startLineNumber: startLine,
-              startColumn: startColumn,
-              endLineNumber: startLine,
-              endColumn: startColumn + interimText.length,
+              startLineNumber: deleteFromPos.lineNumber,
+              startColumn: deleteFromPos.column,
+              endLineNumber: deleteToPos.lineNumber,
+              endColumn: deleteToPos.column,
             },
-            text: transcript,
+            text: insertText,
+            forceMoveMarkers: true,
           },
         ]);
 
+        // executeEdits 後のモデルから末尾位置を計算してカーソルを設定する
+        const newEndOffset = startOffset + transcript.length;
+        const newEndPos = model.getPositionAt(newEndOffset);
+        editorInstance.setPosition(newEndPos);
+
         if (result.isFinal) {
-          // executeEdits 後の実際のカーソル位置を次のフレーズ開始位置とする
-          // （計算値ではなく Monaco が管理する実際の位置を使うことでズレを防ぐ）
-          const pos = editor.getPosition();
-          interimStartLineRef.current = pos?.lineNumber ?? startLine;
-          interimStartColumnRef.current = pos?.column ?? startColumn + transcript.length;
+          // 次フレーズの開始オフセット = 確定テキストの末尾
+          interimStartOffsetRef.current = newEndOffset;
           interimTextRef.current = '';
         } else {
-          // interim テキストを更新
           interimTextRef.current = transcript;
-
-          // カーソルを末尾に移動
-          editor.setPosition({
-            lineNumber: startLine,
-            column: startColumn + transcript.length,
-          });
         }
       }
 
-      editor.focus();
+      editorInstance.focus();
     };
 
     recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
@@ -169,10 +194,14 @@ export const useSpeechRecognition = ({
     const editor = editorRef.current;
     if (!recognition || isListening || isStartingRef.current) return;
 
-    // 音声入力開始時のカーソル位置を記録
+    // 音声入力開始時のカーソル位置をオフセットとして記録
+    const model = editor?.getModel();
     const position = editor?.getPosition();
-    interimStartLineRef.current = position?.lineNumber ?? 1;
-    interimStartColumnRef.current = position?.column ?? 1;
+    if (model && position) {
+      interimStartOffsetRef.current = model.getOffsetAt(position);
+    } else {
+      interimStartOffsetRef.current = 0;
+    }
     interimTextRef.current = '';
 
     try {

--- a/src/hooks/useSpeechRecognition.ts
+++ b/src/hooks/useSpeechRecognition.ts
@@ -85,13 +85,17 @@ export const useSpeechRecognition = ({
   const interimResultsMapRef = useRef<Map<number, ResultPosition>>(new Map());
 
   // ブラウザのSpeechRecognitionサポート判定（マウント時のみ評価）
-  const SpeechRecognitionAPIRef = useRef<SpeechRecognitionConstructor | undefined>(
+  // SSR 時は undefined、クライアント時は API コンストラクタを初期値として保持
+  const SpeechRecognitionAPIRef = useRef(
     typeof window !== 'undefined'
-      ? window.SpeechRecognition || window.webkitSpeechRecognition
+      ? (window.SpeechRecognition ?? window.webkitSpeechRecognition)
       : undefined
   );
 
-  const isSupported = !!SpeechRecognitionAPIRef.current;
+  // isSupported は初期値を固定し、レンダー中に ref.current を読まない
+  const [isSupported] = useState(
+    typeof window !== 'undefined' && !!(window.SpeechRecognition ?? window.webkitSpeechRecognition)
+  );
 
   // isListeningをrefでも管理（useEffect内のクロージャで参照するため）
   useEffect(() => {
@@ -141,6 +145,8 @@ export const useSpeechRecognition = ({
 
     // 認識結果のハンドラー
     recognition.onresult = (event: SpeechRecognitionEvent) => {
+      // 古いインスタンスのイベントは無視
+      if (recognitionRef.current !== recognition) return;
       const editor = editorRef.current;
       if (!editor) return;
 
@@ -273,6 +279,8 @@ export const useSpeechRecognition = ({
 
     // エラーハンドラー
     recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
+      // 古いインスタンスのイベントは無視
+      if (recognitionRef.current !== recognition) return;
       console.error('Speech recognition error:', event.error);
       isStartingRef.current = false;
       if (event.error === 'no-speech' || event.error === 'aborted') {
@@ -287,6 +295,8 @@ export const useSpeechRecognition = ({
 
     // 認識終了ハンドラー
     recognition.onend = () => {
+      // 古いインスタンスのイベントは無視
+      if (recognitionRef.current !== recognition) return;
       setIsListening(false);
       isStartingRef.current = false;
       // Mapをクリア
@@ -297,10 +307,13 @@ export const useSpeechRecognition = ({
     recognitionRef.current = recognition;
 
     return () => {
-      recognition.stop();
+      // リスニング中の場合のみ停止（未起動の recognition に stop() を呼ぶと onend が発火し状態が壊れるため）
+      if (isListeningRef.current) {
+        recognition.stop();
+      }
+      recognitionRef.current = null;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [editorRef]);
 
   const startListening = useCallback(() => {
     const recognition = recognitionRef.current;

--- a/src/hooks/useSpeechRecognition.ts
+++ b/src/hooks/useSpeechRecognition.ts
@@ -122,19 +122,22 @@ export const useSpeechRecognition = ({
         ]);
 
         if (result.isFinal) {
-          // 次のフレーズ開始位置をこの final の末尾に進めて interim をリセット
-          interimStartColumnRef.current = startColumn + transcript.length;
+          // executeEdits 後の実際のカーソル位置を次のフレーズ開始位置とする
+          // （計算値ではなく Monaco が管理する実際の位置を使うことでズレを防ぐ）
+          const pos = editor.getPosition();
+          interimStartLineRef.current = pos?.lineNumber ?? startLine;
+          interimStartColumnRef.current = pos?.column ?? startColumn + transcript.length;
           interimTextRef.current = '';
         } else {
           // interim テキストを更新
           interimTextRef.current = transcript;
-        }
 
-        // カーソルを末尾に移動
-        editor.setPosition({
-          lineNumber: interimStartLineRef.current,
-          column: interimStartColumnRef.current + interimTextRef.current.length,
-        });
+          // カーソルを末尾に移動
+          editor.setPosition({
+            lineNumber: startLine,
+            column: startColumn + transcript.length,
+          });
+        }
       }
 
       editor.focus();

--- a/src/hooks/useSpeechRecognition.ts
+++ b/src/hooks/useSpeechRecognition.ts
@@ -129,14 +129,12 @@ export const useSpeechRecognition = ({
   useEffect(() => {
     if (SpeechRecognitionAPI) {
       const recognition = new SpeechRecognitionAPI();
-      console.log('[SR] new recognition instance:', recognition);
       recognition.continuous = true;
       recognition.interimResults = true;
       recognition.lang = 'ja-JP';
 
       // 認識結果のハンドラー
       recognition.onresult = (event: SpeechRecognitionEvent) => {
-        console.log('[SR] onresult instance:', recognition, 'recognitionRef:', recognitionRef.current);
         const editor = editorRef.current;
         if (!editor) return;
 
@@ -144,7 +142,6 @@ export const useSpeechRecognition = ({
         for (let i = event.resultIndex; i < event.results.length; i++) {
           const result = event.results[i];
           const transcript = result[0].transcript;
-          console.log(`[SR] result[${i}] isFinal:${result.isFinal} transcript:"${transcript}"`);
 
           if (result.isFinal) {
             // 最終結果の処理
@@ -295,10 +292,11 @@ export const useSpeechRecognition = ({
     }
 
     return () => {
-      console.log('[SR] cleanup, recognitionRef:', recognitionRef.current);
       if (recognitionRef.current) {
         recognitionRef.current.stop();
       }
+      finalResultsMapRef.current.clear();
+      interimResultsMapRef.current.clear();
     };
   }, [editorRef, SpeechRecognitionAPI, calculateInsertPosition]);
 

--- a/src/hooks/useSpeechRecognition.ts
+++ b/src/hooks/useSpeechRecognition.ts
@@ -78,39 +78,22 @@ export const useSpeechRecognition = ({
   const [isListening, setIsListening] = useState(false);
   const recognitionRef = useRef<SpeechRecognition | null>(null);
   const isStartingRef = useRef(false);
-  const isListeningRef = useRef(false);
 
   // 各resultインデックスに対応する位置を管理
   const finalResultsMapRef = useRef<Map<number, ResultPosition>>(new Map());
   const interimResultsMapRef = useRef<Map<number, ResultPosition>>(new Map());
 
-  // ブラウザのSpeechRecognitionサポート判定（マウント時のみ評価）
-  // SSR 時は undefined、クライアント時は API コンストラクタを初期値として保持
-  const SpeechRecognitionAPIRef = useRef(
+  // ブラウザのSpeechRecognitionサポート判定（初期化時のみ）
+  const SpeechRecognitionAPI =
     typeof window !== 'undefined'
-      ? (window.SpeechRecognition ?? window.webkitSpeechRecognition)
-      : undefined
-  );
+      ? window.SpeechRecognition || window.webkitSpeechRecognition
+      : undefined;
 
-  // isSupported は初期値を固定し、レンダー中に ref.current を読まない
-  const [isSupported] = useState(
-    typeof window !== 'undefined' && !!(window.SpeechRecognition ?? window.webkitSpeechRecognition)
-  );
+  const isSupported = !!SpeechRecognitionAPI;
 
-  // SpeechRecognition初期化（マウント時のみ）
-  useEffect(() => {
-    const SpeechRecognitionAPI = SpeechRecognitionAPIRef.current;
-    console.log('[SR] useEffect run, SpeechRecognitionAPI:', !!SpeechRecognitionAPI);
-    if (!SpeechRecognitionAPI) return;
-
-    const recognition = new SpeechRecognitionAPI();
-    console.log('[SR] recognition instance created:', recognition);
-    recognition.continuous = true;
-    recognition.interimResults = true;
-    recognition.lang = 'ja-JP';
-
-    // 挿入位置を計算するヘルパー（useEffect内にインライン化）
-    const calculateInsertPosition = (resultIndex: number): { line: number; column: number } => {
+  // 挿入位置を計算するヘルパー
+  const calculateInsertPosition = useCallback(
+    (resultIndex: number): { line: number; column: number } => {
       const editor = editorRef.current;
       if (!editor) return { line: 1, column: 1 };
 
@@ -138,237 +121,208 @@ export const useSpeechRecognition = ({
       return position
         ? { line: position.lineNumber, column: position.column }
         : { line: 1, column: 1 };
-    };
+    },
+    [editorRef]
+  );
 
-    // 認識開始ハンドラー（デバッグ用）
-    (recognition as SpeechRecognition & { onstart: (() => void) | null }).onstart = () => {
-      console.log('[SR] onstart fired - recognition is active');
-    };
+  // SpeechRecognition初期化
+  useEffect(() => {
+    if (SpeechRecognitionAPI) {
+      const recognition = new SpeechRecognitionAPI();
+      recognition.continuous = true;
+      recognition.interimResults = true;
+      recognition.lang = 'ja-JP';
 
-    // 認識結果のハンドラー
-    recognition.onresult = (event: SpeechRecognitionEvent) => {
-      console.log('[SR] onresult fired, resultIndex:', event.resultIndex, 'results.length:', event.results.length);
-      const editor = editorRef.current;
-      console.log('[SR] editor:', !!editor);
-      if (!editor) return;
+      // 認識結果のハンドラー
+      recognition.onresult = (event: SpeechRecognitionEvent) => {
+        const editor = editorRef.current;
+        if (!editor) return;
 
-      // resultIndexからループして処理
-      for (let i = event.resultIndex; i < event.results.length; i++) {
-        const result = event.results[i];
-        const transcript = result[0].transcript;
+        // resultIndexからループして処理
+        for (let i = event.resultIndex; i < event.results.length; i++) {
+          const result = event.results[i];
+          const transcript = result[0].transcript;
 
-        if (result.isFinal) {
-          // 最終結果の処理
-          const interimData = interimResultsMapRef.current.get(i);
+          if (result.isFinal) {
+            // 最終結果の処理
+            const interimData = interimResultsMapRef.current.get(i);
 
-          if (interimData) {
-            // 中間結果を最終結果に置き換え
-            const range = {
-              startLineNumber: interimData.position.line,
-              startColumn: interimData.position.column,
-              endLineNumber: interimData.position.line,
-              endColumn: interimData.position.column + interimData.length,
-            };
+            if (interimData) {
+              // 中間結果を最終結果に置き換え
+              const range = {
+                startLineNumber: interimData.position.line,
+                startColumn: interimData.position.column,
+                endLineNumber: interimData.position.line,
+                endColumn: interimData.position.column + interimData.length,
+              };
 
-            editor.executeEdits('speech-recognition', [
-              {
-                range,
-                text: transcript,
-              },
-            ]);
+              editor.executeEdits('speech-recognition', [
+                {
+                  range,
+                  text: transcript,
+                },
+              ]);
 
-            // finalResultsMapに登録
-            finalResultsMapRef.current.set(i, {
-              position: interimData.position,
-              length: transcript.length,
-            });
+              // finalResultsMapに登録
+              finalResultsMapRef.current.set(i, {
+                position: interimData.position,
+                length: transcript.length,
+              });
 
-            // interimResultsMapから削除
-            interimResultsMapRef.current.delete(i);
+              // interimResultsMapから削除
+              interimResultsMapRef.current.delete(i);
+            } else {
+              // 中間結果がない場合（最初から最終結果）
+              const insertPosition = calculateInsertPosition(i);
+
+              const range = {
+                startLineNumber: insertPosition.line,
+                startColumn: insertPosition.column,
+                endLineNumber: insertPosition.line,
+                endColumn: insertPosition.column,
+              };
+
+              editor.executeEdits('speech-recognition', [
+                {
+                  range,
+                  text: transcript,
+                },
+              ]);
+
+              finalResultsMapRef.current.set(i, {
+                position: insertPosition,
+                length: transcript.length,
+              });
+            }
+
+            // カーソルを最終結果の末尾に移動
+            const finalData = finalResultsMapRef.current.get(i);
+            if (finalData) {
+              editor.setPosition({
+                lineNumber: finalData.position.line,
+                column: finalData.position.column + finalData.length,
+              });
+            }
           } else {
-            // 中間結果がない場合（最初から最終結果）
-            const insertPosition = calculateInsertPosition(i);
+            // 中間結果の処理
+            const existingInterim = interimResultsMapRef.current.get(i);
 
-            const range = {
-              startLineNumber: insertPosition.line,
-              startColumn: insertPosition.column,
-              endLineNumber: insertPosition.line,
-              endColumn: insertPosition.column,
-            };
+            if (existingInterim) {
+              // 既存の中間結果を上書き
+              const range = {
+                startLineNumber: existingInterim.position.line,
+                startColumn: existingInterim.position.column,
+                endLineNumber: existingInterim.position.line,
+                endColumn: existingInterim.position.column + existingInterim.length,
+              };
 
-            editor.executeEdits('speech-recognition', [
-              {
-                range,
-                text: transcript,
-              },
-            ]);
+              editor.executeEdits('speech-recognition', [
+                {
+                  range,
+                  text: transcript,
+                },
+              ]);
 
-            finalResultsMapRef.current.set(i, {
-              position: insertPosition,
-              length: transcript.length,
-            });
-          }
+              interimResultsMapRef.current.set(i, {
+                position: existingInterim.position,
+                length: transcript.length,
+              });
+            } else {
+              // 新しい中間結果
+              const insertPosition = calculateInsertPosition(i);
 
-          // カーソルを最終結果の末尾に移動
-          const finalData = finalResultsMapRef.current.get(i);
-          if (finalData) {
-            editor.setPosition({
-              lineNumber: finalData.position.line,
-              column: finalData.position.column + finalData.length,
-            });
-          }
-        } else {
-          // 中間結果の処理
-          const existingInterim = interimResultsMapRef.current.get(i);
+              const range = {
+                startLineNumber: insertPosition.line,
+                startColumn: insertPosition.column,
+                endLineNumber: insertPosition.line,
+                endColumn: insertPosition.column,
+              };
 
-          if (existingInterim) {
-            // 既存の中間結果を上書き
-            const range = {
-              startLineNumber: existingInterim.position.line,
-              startColumn: existingInterim.position.column,
-              endLineNumber: existingInterim.position.line,
-              endColumn: existingInterim.position.column + existingInterim.length,
-            };
+              editor.executeEdits('speech-recognition', [
+                {
+                  range,
+                  text: transcript,
+                },
+              ]);
 
-            editor.executeEdits('speech-recognition', [
-              {
-                range,
-                text: transcript,
-              },
-            ]);
+              interimResultsMapRef.current.set(i, {
+                position: insertPosition,
+                length: transcript.length,
+              });
+            }
 
-            interimResultsMapRef.current.set(i, {
-              position: existingInterim.position,
-              length: transcript.length,
-            });
-          } else {
-            // 新しい中間結果
-            const insertPosition = calculateInsertPosition(i);
-
-            const range = {
-              startLineNumber: insertPosition.line,
-              startColumn: insertPosition.column,
-              endLineNumber: insertPosition.line,
-              endColumn: insertPosition.column,
-            };
-
-            editor.executeEdits('speech-recognition', [
-              {
-                range,
-                text: transcript,
-              },
-            ]);
-
-            interimResultsMapRef.current.set(i, {
-              position: insertPosition,
-              length: transcript.length,
-            });
-          }
-
-          // カーソルを中間結果の末尾に移動
-          const interimData = interimResultsMapRef.current.get(i);
-          if (interimData) {
-            editor.setPosition({
-              lineNumber: interimData.position.line,
-              column: interimData.position.column + interimData.length,
-            });
-          }
-        }
-      }
-
-      editor.focus();
-    };
-
-    // エラーハンドラー
-    recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
-      console.log('[SR] onerror:', event.error);
-      if (event.error === 'no-speech') {
-        // continuous モードでは一時的に音声が検出されなかっただけ。セッション継続
-        return;
-      }
-      console.error('Speech recognition error:', event.error);
-      isStartingRef.current = false;
-      // not-allowed: マイク許可拒否、audio-capture: マイクなし など致命的なエラーは停止
-      setIsListening(false);
-    };
-
-    // 認識終了ハンドラー
-    recognition.onend = () => {
-      console.log('[SR] onend fired, isListeningRef:', isListeningRef.current);
-      isStartingRef.current = false;
-
-      if (isListeningRef.current) {
-        // ユーザーが意図的に停止していない場合、少し待って再起動
-        // 即時再起動するとブラウザが no-speech ループに入るため遅延させる
-        setTimeout(() => {
-          if (isListeningRef.current && recognitionRef.current) {
-            console.log('[SR] restarting recognition...');
-            try {
-              recognitionRef.current.start();
-            } catch {
-              isListeningRef.current = false;
-              setIsListening(false);
-              finalResultsMapRef.current.clear();
-              interimResultsMapRef.current.clear();
+            // カーソルを中間結果の末尾に移動
+            const interimData = interimResultsMapRef.current.get(i);
+            if (interimData) {
+              editor.setPosition({
+                lineNumber: interimData.position.line,
+                column: interimData.position.column + interimData.length,
+              });
             }
           }
-        }, 300);
-        return;
-      }
+        }
 
-      // stopListening によって意図的に止めた場合
-      setIsListening(false);
-      finalResultsMapRef.current.clear();
-      interimResultsMapRef.current.clear();
-    };
+        editor.focus();
+      };
 
-    recognitionRef.current = recognition;
-    console.log('[SR] recognitionRef set, instance id:', recognition);
+      // エラーハンドラー
+      recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
+        console.error('Speech recognition error:', event.error);
+        isStartingRef.current = false;
+        if (event.error === 'no-speech' || event.error === 'aborted') {
+          // ユーザーが話していない、または中断された場合は自動的に停止
+          setIsListening(false);
+        } else if (event.error === 'not-allowed') {
+          // マイクの許可が拒否された
+          console.error('Microphone permission denied');
+          setIsListening(false);
+        }
+      };
 
-    // クリーンアップ時に ref.current を直接参照しないよう変数にコピー
-    const finalResultsMap = finalResultsMapRef.current;
-    const interimResultsMap = interimResultsMapRef.current;
+      // 認識終了ハンドラー
+      recognition.onend = () => {
+        setIsListening(false);
+        isStartingRef.current = false;
+        // Mapをクリア
+        finalResultsMapRef.current.clear();
+        interimResultsMapRef.current.clear();
+      };
+
+      recognitionRef.current = recognition;
+    }
 
     return () => {
-      console.log('[SR] cleanup called');
-      // ハンドラーを先に無効化してから abort することで、
-      // abort 後に発火する可能性のある onend/onerror の副作用を防ぐ
-      recognition.onresult = null;
-      recognition.onerror = null;
-      recognition.onend = null;
-      recognition.abort();
-      recognitionRef.current = null;
-      // 状態もリセット（onend が呼ばれないためここでリセット）
-      isListeningRef.current = false;
-      setIsListening(false);
-      isStartingRef.current = false;
-      finalResultsMap.clear();
-      interimResultsMap.clear();
+      const r = recognitionRef.current;
+      if (r) {
+        // ハンドラーを無効化してから abort することで、
+        // このインスタンスの結果が editor に書き込まれるのを防ぐ
+        r.onresult = null;
+        r.onend = null;
+        r.onerror = null;
+        r.abort();
+        recognitionRef.current = null;
+      }
     };
-  }, [editorRef]);
+  }, [editorRef, SpeechRecognitionAPI, calculateInsertPosition]);
 
   const startListening = useCallback(() => {
     const recognition = recognitionRef.current;
-    console.log('[SR] startListening called, recognition:', !!recognition, 'isListening:', isListeningRef.current, 'isStarting:', isStartingRef.current);
-    if (!recognition || isListeningRef.current || isStartingRef.current) return;
+    if (!recognition || isListening || isStartingRef.current) return;
 
     try {
       isStartingRef.current = true;
-      isListeningRef.current = true; // setIsListening より先に同期的にフラグを立てる
       recognition.start();
       setIsListening(true);
-      console.log('[SR] recognition.start() called');
     } catch (error) {
       console.error('Failed to start speech recognition:', error);
       isStartingRef.current = false;
-      isListeningRef.current = false;
 
       // already started エラーの場合、一度停止してから再開
       if (error instanceof Error && error.message.includes('already started')) {
         try {
           recognition.stop();
           setTimeout(() => {
-            if (recognitionRef.current && !isListeningRef.current) {
+            if (recognitionRef.current && !isListening) {
               try {
                 isStartingRef.current = true;
                 recognitionRef.current.start();
@@ -384,23 +338,21 @@ export const useSpeechRecognition = ({
         }
       }
     }
-  }, []);
+  }, [isListening]);
 
   const stopListening = useCallback(() => {
     const recognition = recognitionRef.current;
-    if (!recognition || !isListeningRef.current) return;
-
-    // onend での再起動を抑制するために先にフラグを下げる
-    isListeningRef.current = false;
-    setIsListening(false);
+    if (!recognition || !isListening) return;
 
     try {
       recognition.stop();
+      // onend で setIsListening(false) が呼ばれるのを待つ
     } catch (error) {
       console.error('Failed to stop speech recognition:', error);
+      setIsListening(false);
       isStartingRef.current = false;
     }
-  }, []);
+  }, [isListening]);
 
   return {
     isListening,

--- a/src/hooks/useSpeechRecognition.ts
+++ b/src/hooks/useSpeechRecognition.ts
@@ -289,9 +289,24 @@ export const useSpeechRecognition = ({
 
     // 認識終了ハンドラー
     recognition.onend = () => {
-      setIsListening(false);
       isStartingRef.current = false;
-      // Mapをクリア
+
+      // isListening が true のままなら、ユーザーが意図的に停止していない
+      // → continuous モードで no-speech 等により自動終了した場合は再起動する
+      if (isListeningRef.current) {
+        try {
+          recognition.start();
+        } catch {
+          // 再起動に失敗した場合は停止扱いにする
+          setIsListening(false);
+          finalResultsMapRef.current.clear();
+          interimResultsMapRef.current.clear();
+        }
+        return;
+      }
+
+      // stopListening によって意図的に止めた場合
+      setIsListening(false);
       finalResultsMapRef.current.clear();
       interimResultsMapRef.current.clear();
     };
@@ -357,12 +372,14 @@ export const useSpeechRecognition = ({
     const recognition = recognitionRef.current;
     if (!recognition || !isListeningRef.current) return;
 
+    // onend での再起動を抑制するために先にフラグを下げる
+    isListeningRef.current = false;
+    setIsListening(false);
+
     try {
       recognition.stop();
-      // onend で setIsListening(false) が呼ばれるのを待つ
     } catch (error) {
       console.error('Failed to stop speech recognition:', error);
-      setIsListening(false);
       isStartingRef.current = false;
     }
   }, []);

--- a/src/hooks/useSpeechRecognition.ts
+++ b/src/hooks/useSpeechRecognition.ts
@@ -142,6 +142,7 @@ export const useSpeechRecognition = ({
         for (let i = event.resultIndex; i < event.results.length; i++) {
           const result = event.results[i];
           const transcript = result[0].transcript;
+          console.log(`[SR] i=${i} isFinal=${result.isFinal} transcript="${transcript}" interimMap=${JSON.stringify([...interimResultsMapRef.current.entries()])} finalMap=${JSON.stringify([...finalResultsMapRef.current.entries()])}`);
 
           if (result.isFinal) {
             // 最終結果の処理


### PR DESCRIPTION
## Summary
- `useSpeechRecognition` の `useEffect` 依存配列が不安定だったため、コンポーネント再レンダリング時に recognition インスタンスが再生成され、テキストが二重入力されるバグを修正
- `SpeechRecognitionAPI` を `useRef` で保持し、マウント時1回のみ評価するよう変更
- `calculateInsertPosition` を `useEffect` 内にインライン化し、`useEffect` 依存配列を `[]` に変更
- `isListening` を `useRef` でも管理し、`startListening`/`stopListening` の `useCallback` 依存から除外

## Root Cause
```ts
// Before（問題のあるコード）
useEffect(() => { ... }, [editorRef, SpeechRecognitionAPI, calculateInsertPosition]);
//                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
//                        再レンダリング時に再評価され recognition が再生成される
```

再レンダリング時に `useEffect` が再実行 → 古い recognition が `stop()` + Map クリア → 新しいインスタンス生成という流れで状態が壊れ、テキストが二重挿入されていた。

## Test plan
- [x] タスク詳細ページの Monaco Editor で音声入力ボタンをクリック
- [x] 音声入力してテキストが1回のみ挿入されることを確認
- [x] 複数フレーズ連続入力しても二重入力が起きないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)