### PR TITLE
fix: 実行中タスクを最下部にソートするロジックを削除

### DIFF
--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -25,17 +25,8 @@ export function KanbanBoard({
   isAddTaskDialogOpen = false,
   hasApiKey = false,
 }: KanbanBoardProps) {
-  // タスクソート: 人間タスク（上）→ Claude実行中タスク（下、グレーアウト）、それぞれ order 昇順
+  // タスクソート: order 昇順（undefined は最後）
   const sortTasks = (a: Task, b: Task) => {
-    const aIsClaudeRunning = a.tabs?.some((tab) => tab.status === 'running') ?? false;
-    const bIsClaudeRunning = b.tabs?.some((tab) => tab.status === 'running') ?? false;
-
-    // Claude実行中タスクは下に配置
-    if (aIsClaudeRunning !== bIsClaudeRunning) {
-      return aIsClaudeRunning ? 1 : -1;
-    }
-
-    // 同じグループ内では order 順（undefined は最後）
     if (a.order === undefined && b.order === undefined) return 0;
     if (a.order === undefined) return 1;
     if (b.order === undefined) return -1;


### PR DESCRIPTION
## Summary
- KanbanBoard.tsxのsortTasks関数から、実行中タスク（running状態）を最下部に配置するロジックを削除
- タスクはorderフィールドの昇順のみで並び替えられるようになり、実行中になっても位置が変わらない

## Test plan
- [x] タスクが実行中（Claude running）になっても、カラム内の位置が変わらないことを確認
- [x] 通常のorderによるソートが引き続き機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)