### PR TITLE
fix: filterの永続化をlocalStorageからsessionStorageに変更

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -12,22 +12,22 @@ interface FilterState {
   search: string;
 }
 
-// localStorageから読み込み
+// sessionStorageから読み込み
 const loadFilterState = (): FilterState | null => {
   if (typeof window === 'undefined') return null;
   try {
-    const saved = localStorage.getItem(STORAGE_KEY);
+    const saved = sessionStorage.getItem(STORAGE_KEY);
     return saved ? JSON.parse(saved) : null;
   } catch {
     return null;
   }
 };
 
-// localStorageに保存
+// sessionStorageに保存
 const saveFilterState = (state: FilterState) => {
   if (typeof window === 'undefined') return;
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(state));
   } catch {
     // エラーは無視（localStorageが使用できない環境対応）
   }


### PR DESCRIPTION
## Summary

- `Header.tsx` のフィルター永続化を `localStorage` → `sessionStorage` に変更
- タブごとに独立したフィルター状態を保持できるようになる

## 変更箇所

`src/components/Header.tsx` の2箇所のみ：
- `loadFilterState`: `localStorage.getItem` → `sessionStorage.getItem`
- `saveFilterState`: `localStorage.setItem` → `sessionStorage.setItem`

## Test plan

- [x] フィルターを変更し、同タブでリロード → フィルターが維持されること
- [x] 別タブで開いた場合 → 各タブが独自のフィルター状態を持つこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)