### PR TITLE
fix: PTYセッション作成失敗の2つの原因を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "server:dev": "tsx watch server/index.ts",
     "build": "prisma generate && next build",
     "start": "tsx scripts/auto-migrate.ts && concurrently --kill-others --names \"next,fastify\" --prefix-colors \"blue,green\" \"next start -p 2791\" \"tsx server/index.ts\"",
-    "postinstall": "prisma generate && chmod +x node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper 2>/dev/null || true",
+    "postinstall": "prisma generate && chmod +x node_modules/node-pty/prebuilds/*/spawn-helper 2>/dev/null || true",
     "lint": "eslint",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/server/routes/terminal.ts
+++ b/server/routes/terminal.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import type { Server as SocketIOServer } from 'socket.io';
+import * as fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 import { ptyManager } from '../pty-manager.js';
@@ -136,7 +137,18 @@ export async function terminalRoutes(fastify: FastifyInstance) {
     const { cwd, env, sessionId: requestedSessionId, worktreePath, command } = request.body ?? {};
 
     const sessionId = requestedSessionId ?? crypto.randomUUID();
-    const workingDir = cwd ?? path.join(os.homedir(), '.tsunagi', 'workspaces');
+    const defaultDir = path.join(os.homedir(), '.tsunagi', 'workspaces');
+    let workingDir = cwd ?? defaultDir;
+
+    // cwd が存在するか確認、なければデフォルトにフォールバック
+    try {
+      await fs.access(workingDir);
+    } catch {
+      fastify.log.warn({ workingDir }, 'cwd does not exist, falling back to default');
+      workingDir = defaultDir;
+    }
+    // デフォルトディレクトリが存在しない場合も作成する
+    await fs.mkdir(workingDir, { recursive: true });
 
     // 既存セッションが生きていれば再利用
     const existing = ptyManager.getSession(sessionId);


### PR DESCRIPTION
- server/routes/terminal.ts: cwdが存在しない場合にデフォルトディレクトリへフォールバックする処理を追加。worktreeが未作成のタスクでもPTYが起動できるようにする
- package.json: postinstallのchmodをdarin-arm64限定からグロブ（*/）に変更し、全プラットフォームのspawn-helperに実行権限を付与するよう修正