### PR TITLE
fix: タスク作成後にKanbanボードがリアルタイム更新されない問題を修正

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -4,6 +4,7 @@ import fastifySocketIO from 'fastify-socket.io';
 import { terminalRoutes } from './routes/terminal.js';
 import { hooksRoutes } from './routes/hooks.js';
 import { mcpRoutes } from './routes/mcp.js';
+import { tasksRoutes } from './routes/tasks.js';
 
 const PORT = 2792;
 
@@ -25,6 +26,7 @@ async function start() {
   await fastify.register(terminalRoutes);
   await fastify.register(hooksRoutes);
   await fastify.register(mcpRoutes);
+  await fastify.register(tasksRoutes);
 
   await fastify.listen({ port: PORT, host: '0.0.0.0' });
   console.log(`Fastify server running on port ${PORT}`);

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -1,0 +1,156 @@
+import type { FastifyInstance } from 'fastify';
+import type { Server as SocketIOServer } from 'socket.io';
+import * as taskRepo from '../../src/lib/repositories/task.js';
+import * as repoRepo from '../../src/lib/repositories/repository.js';
+import * as worktreeManager from '../../src/lib/worktree-manager.js';
+
+interface FastifyWithIO extends FastifyInstance {
+  io: SocketIOServer;
+}
+
+interface ValidateBody {
+  title: string;
+  owner: string;
+  repo: string;
+  branch: string;
+}
+
+interface CreateBody {
+  title: string;
+  description?: string;
+  owner: string;
+  repo: string;
+  branch: string;
+  baseBranch?: string;
+  effort?: number;
+  order?: number;
+}
+
+export async function tasksRoutes(fastify: FastifyInstance) {
+  const io = (fastify as FastifyWithIO).io;
+
+  // POST /tasks/validate
+  fastify.post<{ Body: ValidateBody }>('/tasks/validate', async (request, reply) => {
+    const { title, owner, repo, branch } = request.body;
+
+    if (!title || !owner || !repo || !branch) {
+      return reply.status(400).send({
+        valid: false,
+        errors: [
+          { field: 'global', message: 'Missing required fields: title, owner, repo, branch' },
+        ],
+      });
+    }
+
+    const existingTasks = await taskRepo.getTasks({ includeDeleted: false });
+    const duplicateTask = existingTasks.find(
+      (task) => task.owner === owner && task.repo === repo && task.branch === branch
+    );
+
+    if (duplicateTask) {
+      return reply.status(409).send({
+        valid: false,
+        errors: [
+          {
+            field: 'branch',
+            message: `Branch "${branch}" already exists. Task "${duplicateTask.title}" (ID: ${duplicateTask.id}) is already using this branch.`,
+          },
+        ],
+      });
+    }
+
+    return reply.status(200).send({ valid: true });
+  });
+
+  // POST /tasks
+  fastify.post<{ Body: CreateBody }>('/tasks', async (request, reply) => {
+    const { title, description, owner, repo, branch, baseBranch, effort, order } = request.body;
+
+    if (!title || !owner || !repo || !branch) {
+      return reply.status(400).send({
+        errors: [
+          { field: 'global', message: 'Missing required fields: title, owner, repo, branch' },
+        ],
+      });
+    }
+
+    // ブランチ名重複チェック
+    const existingTasks = await taskRepo.getTasks({ includeDeleted: false });
+    const duplicateTask = existingTasks.find(
+      (task) => task.owner === owner && task.repo === repo && task.branch === branch
+    );
+
+    if (duplicateTask) {
+      return reply.status(409).send({
+        errors: [
+          {
+            field: 'branch',
+            message: `Branch "${branch}" already exists. Task "${duplicateTask.title}" (ID: ${duplicateTask.id}) is already using this branch.`,
+          },
+        ],
+      });
+    }
+
+    // リポジトリIDを取得
+    const repository = await repoRepo.getRepo(owner, repo);
+    if (!repository) {
+      return reply.status(404).send({
+        errors: [
+          { field: 'global', message: 'Repository not found. Please clone the repository first.' },
+        ],
+      });
+    }
+
+    // タスクを作成
+    const newTask = await taskRepo.createTask({
+      title,
+      description: description ?? '',
+      status: 'backlog',
+      owner,
+      repo,
+      branch,
+      baseBranch: baseBranch ?? 'main',
+      repoId: repository.id,
+      worktreeStatus: 'pending',
+      effort,
+      order,
+    });
+
+    // worktreeを自動作成
+    try {
+      await worktreeManager.fetchRemote(owner, repo);
+      const { baseBranchCommit } = await worktreeManager.createWorktree(
+        owner,
+        repo,
+        branch,
+        baseBranch ?? 'main'
+      );
+      await taskRepo.updateTask(newTask.id, { worktreeStatus: 'created', baseBranchCommit });
+    } catch (error) {
+      fastify.log.error(error, 'Failed to create worktree');
+      await taskRepo.updateTask(newTask.id, { worktreeStatus: 'error' });
+    }
+
+    // 最初のタブを自動作成
+    try {
+      await taskRepo.createTab(newTask.id);
+    } catch (error) {
+      fastify.log.error(error, 'Failed to create initial tab');
+    }
+
+    // 更新後のタスクを取得
+    const updatedTask = await taskRepo.getTask(newTask.id);
+
+    // task:created イベントを全クライアントにbroadcast
+    const taskForBroadcast = {
+      ...updatedTask,
+      tabs: (updatedTask?.tabs ?? []).map((tab) => ({
+        ...tab,
+        promptCount: tab.promptCount ?? 0,
+      })),
+    };
+    io.emit('task:created', { task: taskForBroadcast });
+
+    return reply.status(201).send({ data: { task: taskForBroadcast } });
+  });
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,6 +12,7 @@ import { CloneRepositoryDialog } from '@/components/CloneRepositoryDialog';
 import { BatchDeleteDialog } from '@/components/BatchDeleteDialog';
 import { useBatchDelete } from '@/hooks/useBatchDelete';
 import { useTerminalTodos } from '@/hooks/useTerminalTodos';
+import { useTaskEvents } from '@/hooks/useTaskEvents';
 import { toaster } from '@/lib/toaster';
 
 export default function Home() {
@@ -114,6 +115,11 @@ export default function Home() {
 
   // KanbanカードのProgress Bar用Todos
   const tabTodosMap = useTerminalTodos(runningTabIds);
+
+  // task:created イベントを受信してKanbanボードを即時更新
+  useTaskEvents((newTask) => {
+    setTasks((prev) => [...prev, newTask]);
+  });
 
   // バッチ削除
   const { isDeleting, deletedCount, errorCount, totalCount, isCompleted, startBatchDelete, reset } =

--- a/src/components/TaskDialog.tsx
+++ b/src/components/TaskDialog.tsx
@@ -174,7 +174,7 @@ export function TaskDialog({
 
       try {
         // 1. Validation API (blocking)
-        const validateRes = await fetch('/api/tasks/validate', {
+        const validateRes = await fetch('http://localhost:2792/tasks/validate', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -226,7 +226,7 @@ export function TaskDialog({
         const notificationId = toast.loading('Creating task...', taskData.title);
 
         try {
-          const response = await fetch('/api/tasks', {
+          const response = await fetch('http://localhost:2792/tasks', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(taskData),

--- a/src/hooks/useTaskEvents.ts
+++ b/src/hooks/useTaskEvents.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useLayoutEffect, useRef } from 'react';
 import { io, type Socket } from 'socket.io-client';
 import type { Task } from '@/lib/types';
 
@@ -9,7 +9,10 @@ const FASTIFY_API_BASE = 'http://localhost:2792';
 export function useTaskEvents(onTaskCreated: (task: Task) => void) {
   const socketRef = useRef<Socket | null>(null);
   const callbackRef = useRef(onTaskCreated);
-  callbackRef.current = onTaskCreated;
+
+  useLayoutEffect(() => {
+    callbackRef.current = onTaskCreated;
+  });
 
   useEffect(() => {
     const socket = io(FASTIFY_API_BASE, { transports: ['websocket'] });

--- a/src/hooks/useTaskEvents.ts
+++ b/src/hooks/useTaskEvents.ts
@@ -1,0 +1,27 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { io, type Socket } from 'socket.io-client';
+import type { Task } from '@/lib/types';
+
+const FASTIFY_API_BASE = 'http://localhost:2792';
+
+export function useTaskEvents(onTaskCreated: (task: Task) => void) {
+  const socketRef = useRef<Socket | null>(null);
+  const callbackRef = useRef(onTaskCreated);
+  callbackRef.current = onTaskCreated;
+
+  useEffect(() => {
+    const socket = io(FASTIFY_API_BASE, { transports: ['websocket'] });
+    socketRef.current = socket;
+
+    socket.on('task:created', ({ task }: { task: Task }) => {
+      callbackRef.current(task);
+    });
+
+    return () => {
+      socket.disconnect();
+      socketRef.current = null;
+    };
+  }, []);
+}


### PR DESCRIPTION
- Fastifyにタスク作成エンドポイント(POST /tasks, POST /tasks/validate)を追加
- タスク作成成功時にSocket.IOで task:created イベントをbroadcast
- useTaskEventsフックを追加してtask:createdイベントをlistenし、stateを即時更新
- TaskDialogのAPIコールをNext.js APIルートからFastifyエンドポイントに移行