### PR TITLE
fix: タブステータスの永続化バグ修正とKanbanBoardリアルタイム更新

### DIFF
--- a/server/routes/hooks.ts
+++ b/server/routes/hooks.ts
@@ -91,6 +91,7 @@ export async function hooksRoutes(fastify: FastifyInstance) {
 
         case 'PermissionRequest':
           // ツール実行許可待ち → waiting状態に更新
+          await updateTabStatus(sessionId, 'waiting');
           io.to(room).emit('status-changed', { sessionId, status: 'waiting' });
           break;
 
@@ -106,6 +107,7 @@ export async function hooksRoutes(fastify: FastifyInstance) {
               io.to(room).emit('todos-updated', { sessionId, todos });
             }
           }
+          await updateTabStatus(sessionId, 'running');
           io.to(room).emit('status-changed', { sessionId, status: 'running' });
           break;
 
@@ -115,7 +117,7 @@ export async function hooksRoutes(fastify: FastifyInstance) {
 
         case 'Stop':
           // 正常完了 → success状態に更新
-          await updateTabStatus(sessionId, 'idle');
+          await updateTabStatus(sessionId, 'success');
           io.to(room).emit('status-changed', { sessionId, status: 'success' });
           break;
 

--- a/server/routes/mcp.ts
+++ b/server/routes/mcp.ts
@@ -293,12 +293,12 @@ export async function mcpRoutes(fastify: FastifyInstance) {
       transports.delete(transport.sessionId);
     });
 
-    const server = createMcpServer();
-    await server.connect(transport);
-
     // Fastifyのデフォルトレスポンス処理をスキップ
     await reply.hijack();
-    await transport.start();
+
+    const server = createMcpServer();
+    // server.connect() が内部で transport.start() を呼ぶため、明示的な start() は不要
+    await server.connect(transport);
   });
 
   // POST /mcp - tool呼び出しエンドポイント

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,6 +13,7 @@ import { BatchDeleteDialog } from '@/components/BatchDeleteDialog';
 import { useBatchDelete } from '@/hooks/useBatchDelete';
 import { useTerminalTodos } from '@/hooks/useTerminalTodos';
 import { useTaskEvents } from '@/hooks/useTaskEvents';
+import { useTabStatusEvents } from '@/hooks/useTabStatusEvents';
 import { toaster } from '@/lib/toaster';
 
 export default function Home() {
@@ -104,6 +105,12 @@ export default function Home() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // 全タスクの全タブIDリスト（useTabStatusEventsに渡す）
+  const allTabIds = useMemo(
+    () => tasks.flatMap((t) => (t.tabs ?? []).map((tab) => tab.tab_id)),
+    [tasks]
+  );
+
   // running中のタブのIDリスト（useTerminalTodosに渡す）
   const runningTabIds = useMemo(
     () =>
@@ -115,6 +122,16 @@ export default function Home() {
 
   // KanbanカードのProgress Bar用Todos
   const tabTodosMap = useTerminalTodos(runningTabIds);
+
+  // タブのステータス変更をリアルタイムでKanbanボードに反映
+  useTabStatusEvents(allTabIds, (tabId, status) => {
+    setTasks((prev) =>
+      prev.map((task) => ({
+        ...task,
+        tabs: (task.tabs ?? []).map((tab) => (tab.tab_id === tabId ? { ...tab, status } : tab)),
+      }))
+    );
+  });
 
   // task:created イベントを受信してKanbanボードを即時更新
   useTaskEvents((newTask) => {

--- a/src/components/ClaudeState.tsx
+++ b/src/components/ClaudeState.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Loader2, CheckCircle2, XCircle, Circle } from 'lucide-react';
+import { Loader2, CheckCircle2, XCircle, Circle, MessageSquare } from 'lucide-react';
 import type { TabStatus } from '@/lib/claude-status';
 
 interface ClaudeStateProps {
@@ -13,6 +13,8 @@ export function ClaudeState({ status, showLabel = true }: ClaudeStateProps) {
     switch (status) {
       case 'running':
         return <Loader2 className="w-4 h-4 text-primary animate-spin" />;
+      case 'waiting':
+        return <MessageSquare className="w-4 h-4 text-yellow-500" />;
       case 'success':
         return <CheckCircle2 className="w-4 h-4 text-green-500" />;
       case 'error':

--- a/src/hooks/useTabStatusEvents.ts
+++ b/src/hooks/useTabStatusEvents.ts
@@ -1,0 +1,94 @@
+'use client';
+
+import { useEffect, useRef, useCallback } from 'react';
+import { io, type Socket } from 'socket.io-client';
+import type { Tab } from '@/lib/types';
+
+const FASTIFY_API_BASE = 'http://localhost:2792';
+
+// Socket.IOのClaudeStatusをTab.statusにマッピング
+function toTabStatus(claudeStatus: string): Tab['status'] | null {
+  switch (claudeStatus) {
+    case 'running':
+      return 'running';
+    case 'waiting':
+      return 'waiting';
+    case 'success':
+      return 'success';
+    case 'failure':
+    case 'error':
+      return 'error';
+    case 'idle':
+      return 'idle';
+    default:
+      return null;
+  }
+}
+
+/**
+ * 指定したタブIDのSocket.IO roomを購読し、status-changedイベントを受信するhook。
+ * KanbanBoardのリアルタイムステータス更新に使用。
+ */
+export function useTabStatusEvents(
+  tabIds: string[],
+  onStatusChange: (tabId: string, status: Tab['status']) => void
+): void {
+  const socketRef = useRef<Socket | null>(null);
+  const joinedRoomsRef = useRef<Set<string>>(new Set());
+  const onStatusChangeRef = useRef(onStatusChange);
+
+  useEffect(() => {
+    onStatusChangeRef.current = onStatusChange;
+  });
+
+  const ensureConnected = useCallback(() => {
+    if (!socketRef.current) {
+      const socket = io(FASTIFY_API_BASE, { transports: ['websocket'] });
+      socketRef.current = socket;
+
+      socket.on(
+        'status-changed',
+        ({ sessionId, status }: { sessionId: string; status: string }) => {
+          const tabStatus = toTabStatus(status);
+          if (tabStatus !== null) {
+            onStatusChangeRef.current(sessionId, tabStatus);
+          }
+        }
+      );
+    }
+    return socketRef.current;
+  }, []);
+
+  useEffect(() => {
+    if (tabIds.length === 0) return;
+
+    const socket = ensureConnected();
+
+    // 新しいタブのroomに参加
+    for (const tabId of tabIds) {
+      const room = `tab:${tabId}`;
+      if (!joinedRoomsRef.current.has(room)) {
+        socket.emit('join', { room });
+        joinedRoomsRef.current.add(room);
+      }
+    }
+
+    // 不要になったroomから退出
+    const tabIdSet = new Set(tabIds);
+    for (const room of joinedRoomsRef.current) {
+      const tabId = room.replace('tab:', '');
+      if (!tabIdSet.has(tabId)) {
+        socket.emit('leave', { room });
+        joinedRoomsRef.current.delete(room);
+      }
+    }
+  }, [tabIds, ensureConnected]);
+
+  useEffect(() => {
+    return () => {
+      socketRef.current?.disconnect();
+      socketRef.current = null;
+      joinedRoomsRef.current.clear();
+    };
+  }, []);
+}

--- a/src/lib/claude-status.ts
+++ b/src/lib/claude-status.ts
@@ -1,6 +1,6 @@
 import type { Tab } from './types';
 
-export type TabStatus = 'idle' | 'running' | 'success' | 'error';
+export type TabStatus = 'idle' | 'running' | 'waiting' | 'success' | 'error';
 
 /**
  * Get the current Claude tab status

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -34,7 +34,7 @@ export interface Task {
 export interface Tab {
   tab_id: string; // UUID（タブ作成時に生成）
   order: number; // タブ表示用の連番
-  status: 'idle' | 'running' | 'success' | 'error';
+  status: 'idle' | 'running' | 'waiting' | 'success' | 'error';
   startedAt: string;
   completedAt?: string;
   updatedAt: string;


### PR DESCRIPTION
- Stop hookのDB保存値を 'idle' → 'success' に修正（根本原因）
- PermissionRequest/PostToolUse hookにDB更新を追加し状態を正確に永続化
- MCPの二重start()バグを修正（SSEServerTransport already startedエラー解消）
- Tab.status型に 'waiting' を追加
- useTabStatusEvents hookを新規作成してKanbanBoardをリアルタイム更新
- ClaudeStateに waiting状態のUIを追加