### PR TITLE
fix: 複数タブ切り替え時に前のタブで入力できなくなる問題を修正

### DIFF
--- a/scripts/monaco-editor.sh
+++ b/scripts/monaco-editor.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# monaco-editor.sh
+# $EDITOR として設定することで、Claude Code の Ctrl+G でブラウザ上の
+# Monaco Editor Modal を開いてプロンプトを編集できる。
+#
+# セットアップ:
+#   export EDITOR="/path/to/scripts/monaco-editor.sh"
+#
+# 依存: curl のみ
+
+set -e
+
+TMPFILE="$1"
+API_BASE="http://localhost:2792"
+
+if [ -z "$TMPFILE" ]; then
+  echo "Usage: monaco-editor.sh <tmpfile>" >&2
+  exit 1
+fi
+
+# ファイルパスを送信。サーバー側がファイルの読み書きを行う。
+# レスポンスはプレーンテキストの sessionId のみ（JSON パース不要）
+SESSION_ID=$(curl -sf -X POST "$API_BASE/api/editor/session" \
+  -H "Content-Type: application/json" \
+  -d "{\"filePath\": \"$TMPFILE\"}")
+
+if [ -z "$SESSION_ID" ]; then
+  echo "Error: Failed to create editor session (is tsunagi running? check monaco-editor.sh setup)" >&2
+  exit 1
+fi
+
+echo "Opening Monaco Editor in browser... (session: $SESSION_ID)" >&2
+
+# 完了までポーリング（最大10分、1秒間隔）
+# レスポンスはプレーンテキスト "done" or "pending"（JSON パース不要）
+i=0
+while [ $i -lt 600 ]; do
+  STATUS=$(curl -sf "$API_BASE/api/editor/session/$SESSION_ID" 2>/dev/null || echo "pending")
+  if [ "$STATUS" = "done" ]; then
+    exit 0
+  fi
+  sleep 1
+  i=$((i + 1))
+done
+
+echo "Error: Timed out waiting for editor (10 min)" >&2
+exit 1

--- a/server/editor-session-store.ts
+++ b/server/editor-session-store.ts
@@ -1,0 +1,18 @@
+interface EditorSession {
+  filePath: string;
+  content: string;
+  status: 'pending' | 'done';
+  createdAt: number;
+}
+
+export const editorSessionStore = new Map<string, EditorSession>();
+
+// 10分以上経過したセッションを定期クリーンアップ
+setInterval(() => {
+  const threshold = Date.now() - 10 * 60 * 1000;
+  for (const [id, session] of editorSessionStore) {
+    if (session.createdAt < threshold) {
+      editorSessionStore.delete(id);
+    }
+  }
+}, 60 * 1000);

--- a/server/index.ts
+++ b/server/index.ts
@@ -5,6 +5,7 @@ import { terminalRoutes } from './routes/terminal.js';
 import { hooksRoutes } from './routes/hooks.js';
 import { mcpRoutes } from './routes/mcp.js';
 import { tasksRoutes } from './routes/tasks.js';
+import { editorRoutes } from './routes/editor.js';
 
 const PORT = 2792;
 
@@ -27,6 +28,7 @@ async function start() {
   await fastify.register(hooksRoutes);
   await fastify.register(mcpRoutes);
   await fastify.register(tasksRoutes);
+  await fastify.register(editorRoutes);
 
   await fastify.listen({ port: PORT, host: '0.0.0.0' });
   console.log(`Fastify server running on port ${PORT}`);

--- a/server/routes/editor.ts
+++ b/server/routes/editor.ts
@@ -1,0 +1,66 @@
+import { readFile, writeFile } from 'fs/promises';
+import type { FastifyInstance } from 'fastify';
+import type { Server as SocketIOServer } from 'socket.io';
+import { randomUUID } from 'crypto';
+import { editorSessionStore } from '../editor-session-store.js';
+
+interface FastifyWithIO extends FastifyInstance {
+  io: SocketIOServer;
+}
+
+export async function editorRoutes(fastify: FastifyInstance) {
+  const f = fastify as FastifyWithIO;
+
+  // セッション作成: CLIスクリプトが filePath を送信、サーバーがファイルを読む
+  f.post<{ Body: { filePath: string } }>('/api/editor/session', async (request, reply) => {
+    const { filePath } = request.body;
+    if (!filePath) {
+      return reply.status(400).send('filePath is required');
+    }
+
+    let content = '';
+    try {
+      content = await readFile(filePath, 'utf8');
+    } catch {
+      // ファイルが存在しない or 空の場合は空文字で続行
+    }
+
+    const sessionId = randomUUID();
+    editorSessionStore.set(sessionId, {
+      filePath,
+      content,
+      status: 'pending',
+      createdAt: Date.now(),
+    });
+
+    // 全ブラウザクライアントに editor:open を送信
+    f.io.emit('editor:open', { sessionId, content });
+
+    // sessionId のみプレーンテキストで返す（Shell script が JSON パース不要）
+    return reply.type('text/plain').send(sessionId);
+  });
+
+  // セッション状態取得: CLIスクリプトがポーリングで使用
+  // "done" or "pending" をプレーンテキストで返す（Shell script が JSON パース不要）
+  f.get<{ Params: { id: string } }>('/api/editor/session/:id', async (request, reply) => {
+    const session = editorSessionStore.get(request.params.id);
+    if (!session) {
+      return reply.status(404).send('not found');
+    }
+    return reply.type('text/plain').send(session.status);
+  });
+
+  // セッション完了: ブラウザが編集完了時に呼び出す。サーバーがファイルに書き戻す
+  f.post<{ Params: { id: string }; Body: { content: string } }>(
+    '/api/editor/session/:id/complete',
+    async (request, reply) => {
+      const session = editorSessionStore.get(request.params.id);
+      if (!session) {
+        return reply.status(404).send({ error: 'Session not found' });
+      }
+      await writeFile(session.filePath, request.body.content, 'utf8');
+      session.status = 'done';
+      return reply.send({ ok: true });
+    }
+  );
+}

--- a/server/routes/terminal.ts
+++ b/server/routes/terminal.ts
@@ -6,6 +6,9 @@ import * as path from 'path';
 import { ptyManager } from '../pty-manager.js';
 import { prisma } from '../../src/lib/db.js';
 
+// サーバーはプロジェクトルートから起動されるため process.cwd() でルートを取得
+const TSUNAGI_EDITOR_PATH = path.resolve(process.cwd(), 'scripts/monaco-editor.sh');
+
 interface FastifyWithIO extends FastifyInstance {
   io: SocketIOServer;
 }
@@ -172,8 +175,11 @@ export async function terminalRoutes(fastify: FastifyInstance) {
         fastify.log.warn({ err }, 'Failed to load global env vars');
       }
 
-      // 優先順位: リクエストで渡されたenv > DBのglobal env
-      const mergedEnv = { ...globalEnv, ...env };
+      // 優先順位: リクエストで渡されたenv > DBのglobal env > tsunagi独自のEDITOR設定
+      // tsunagi-editor.sh をデフォルトにすることで Ctrl+G が Monaco Modal を開く。
+      // DB / リクエストで EDITOR が明示設定されている場合はそちらが優先される。
+      const tsunagiDefaultEnv: Record<string, string> = { EDITOR: TSUNAGI_EDITOR_PATH };
+      const mergedEnv = { ...tsunagiDefaultEnv, ...globalEnv, ...env };
 
       const session = ptyManager.createSession(sessionId, workingDir, mergedEnv);
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import './globals.css';
 import { ThemeProvider } from '@/contexts/ThemeContext';
 import { ConnectionStatus } from '@/components/ConnectionStatus';
 import { ToastProvider } from '@/components/ToastProvider';
+import { EditorSessionProvider } from '@/components/EditorSessionProvider';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -32,6 +33,7 @@ export default function RootLayout({
           {children}
           <ConnectionStatus />
           <ToastProvider />
+          <EditorSessionProvider />
         </ThemeProvider>
       </body>
     </html>

--- a/src/app/tasks/[id]/page.tsx
+++ b/src/app/tasks/[id]/page.tsx
@@ -201,7 +201,7 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
             Back to Board
           </button>
 
-          <h1 className="text-xl font-bold text-theme-fg absolute left-1/2 -translate-x-1/2">
+          <h1 className="text-base font-semibold text-theme-fg absolute left-1/2 -translate-x-1/2 max-w-[50vw] truncate">
             {task.title}
           </h1>
 

--- a/src/components/EditorSessionProvider.tsx
+++ b/src/components/EditorSessionProvider.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { io } from 'socket.io-client';
+import { MonacoEditorModal } from '@/components/MonacoEditorModal';
+
+const FASTIFY_API_BASE = 'http://localhost:2792';
+
+interface EditorSession {
+  sessionId: string;
+  content: string;
+}
+
+export function EditorSessionProvider() {
+  const [session, setSession] = useState<EditorSession | null>(null);
+
+  useEffect(() => {
+    const socket = io(FASTIFY_API_BASE, { transports: ['websocket'] });
+
+    socket.on('editor:open', ({ sessionId, content }: EditorSession) => {
+      setSession({ sessionId, content });
+    });
+
+    return () => {
+      socket.disconnect();
+    };
+  }, []);
+
+  // session が非null → null に変化したタイミングで正確に1回だけ発火する。
+  // Esc / Cancel / Submit どのパスで閉じても確実に Ctrl+L がターミナルに送られる。
+  const prevSessionRef = useRef<EditorSession | null>(null);
+  useEffect(() => {
+    if (prevSessionRef.current !== null && session === null) {
+      window.dispatchEvent(new CustomEvent('editor-session-done'));
+    }
+    prevSessionRef.current = session;
+  }, [session]);
+
+  async function handleSubmit(text: string) {
+    if (!session) return;
+    await fetch(`${FASTIFY_API_BASE}/api/editor/session/${session.sessionId}/complete`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: text }),
+    });
+    setSession(null);
+  }
+
+  async function handleCancel() {
+    if (!session) return;
+    // Cancel / Esc / × ボタンで閉じた場合、元のコンテンツで complete を呼ぶ。
+    // これにより shell script が正常終了し、Claude Code は元の状態に戻る。
+    await fetch(`${FASTIFY_API_BASE}/api/editor/session/${session.sessionId}/complete`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: session.content }),
+    });
+    setSession(null);
+  }
+
+  return (
+    <MonacoEditorModal
+      open={session !== null}
+      onOpenChange={(details) => {
+        if (!details.open) handleCancel();
+      }}
+      onSubmit={handleSubmit}
+      initialValue={session?.content ?? ''}
+      title="Edit Prompt"
+      submitLabel="Submit"
+    />
+  );
+}

--- a/src/components/EditorSessionProvider.tsx
+++ b/src/components/EditorSessionProvider.tsx
@@ -26,11 +26,16 @@ export function EditorSessionProvider() {
     };
   }, []);
 
-  // session が非null → null に変化したタイミングで正確に1回だけ発火する。
-  // Esc / Cancel / Submit どのパスで閉じても確実に Ctrl+L がターミナルに送られる。
+  // session の変化を監視してカスタムイベントを発火する。
+  // open: xterm の blur と customKeyEventHandler の無効化を TerminalView に通知
+  // done: Ctrl+L 送信と focus 復帰を TerminalView に通知
   const prevSessionRef = useRef<EditorSession | null>(null);
   useEffect(() => {
-    if (prevSessionRef.current !== null && session === null) {
+    const prev = prevSessionRef.current;
+    if (prev === null && session !== null) {
+      window.dispatchEvent(new CustomEvent('editor-session-open'));
+    }
+    if (prev !== null && session === null) {
       window.dispatchEvent(new CustomEvent('editor-session-done'));
     }
     prevSessionRef.current = session;

--- a/src/components/MonacoEditorModal.tsx
+++ b/src/components/MonacoEditorModal.tsx
@@ -30,6 +30,8 @@ export function MonacoEditorModal({
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
   const handleSubmitRef = useRef<() => void>(() => {});
   const handleCancelRef = useRef<() => void>(() => {});
+  // open 状態を ref で保持: onDidLayoutChange ハンドラから参照するため
+  const openRef = useRef(open);
   const { effectiveTheme } = useTheme();
 
   function handleSubmit() {
@@ -43,16 +45,27 @@ export function MonacoEditorModal({
   useLayoutEffect(() => {
     handleSubmitRef.current = handleSubmit;
     handleCancelRef.current = handleCancel;
+    openRef.current = open;
   });
 
-  // open または initialValue が変化したとき、既にマウント済みのエディタに反映
+  // open が true になったとき editor.layout() を呼ぶ。
+  // layout() によりサイズが 0→実サイズに変わると onDidLayoutChange が発火し、
+  // そこで focus() が呼ばれる（onMount で登録済み）。
   useEffect(() => {
-    if (open && editorRef.current) {
-      editorRef.current.setValue(initialValue ?? '');
-      // カーソルを先頭に移動してフォーカス
-      editorRef.current.setPosition({ lineNumber: 1, column: 1 });
-      editorRef.current.focus();
-    }
+    if (!open || !editorRef.current) return;
+    editorRef.current.setValue(initialValue ?? '');
+    editorRef.current.setPosition({ lineNumber: 1, column: 1 });
+    // layout() → onDidLayoutChange → focus() のチェーンを起動
+    editorRef.current.layout();
+
+    // フォールバック: onDidLayoutChange が発火しない場合（サイズ変化なし等）に備える
+    const timer = setTimeout(() => {
+      if (openRef.current) {
+        editorRef.current?.layout();
+        editorRef.current?.focus();
+      }
+    }, 50);
+    return () => clearTimeout(timer);
   }, [open, initialValue]);
 
   return (
@@ -77,18 +90,26 @@ export function MonacoEditorModal({
             defaultValue=""
             onMount={(editorInstance, monacoInstance) => {
               editorRef.current = editorInstance;
-              // 初期コンテンツをセットしカーソルを先頭に
               editorInstance.setValue(initialValue ?? '');
               editorInstance.setPosition({ lineNumber: 1, column: 1 });
+
+              // レイアウト変化時に自動フォーカス（Dialog 表示で 0→実サイズに変化した瞬間）
+              editorInstance.onDidLayoutChange(() => {
+                if (openRef.current && !editorInstance.hasTextFocus()) {
+                  editorInstance.focus();
+                }
+              });
+
+              // 初回マウント時
+              editorInstance.layout();
               editorInstance.focus();
+
               editorInstance.onKeyDown((e) => {
-                // Cmd/Ctrl+Enter: 送信
                 if (e.keyCode === monacoInstance.KeyCode.Enter && (e.metaKey || e.ctrlKey)) {
                   e.preventDefault();
                   e.stopPropagation();
                   handleSubmitRef.current();
                 }
-                // Esc: キャンセル（Monaco がイベントを消費するため明示的に処理）
                 if (e.keyCode === monacoInstance.KeyCode.Escape) {
                   e.preventDefault();
                   e.stopPropagation();

--- a/src/components/MonacoEditorModal.tsx
+++ b/src/components/MonacoEditorModal.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import { useRef, useEffect, useLayoutEffect } from 'react';
+import { Editor } from '@monaco-editor/react';
+import type { editor } from 'monaco-editor';
+import { useTheme } from '@/contexts/ThemeContext';
+import { Dialog } from '@/components/ui/Dialog';
+
+export interface MonacoEditorModalProps {
+  open: boolean;
+  onOpenChange: (details: { open: boolean }) => void;
+  /** 編集確定時のコールバック。テキストを受け取り呼び出し元が処理する */
+  onSubmit: (text: string) => void;
+  initialValue?: string;
+  title?: string;
+  /** 確定ボタンのラベル（デフォルト: "Submit"） */
+  submitLabel?: string;
+}
+
+const isMac = typeof navigator !== 'undefined' && /Mac/.test(navigator.platform);
+
+export function MonacoEditorModal({
+  open,
+  onOpenChange,
+  onSubmit,
+  initialValue = '',
+  title = 'Editor',
+  submitLabel = 'Submit',
+}: MonacoEditorModalProps) {
+  const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
+  const handleSubmitRef = useRef<() => void>(() => {});
+  const handleCancelRef = useRef<() => void>(() => {});
+  const { effectiveTheme } = useTheme();
+
+  function handleSubmit() {
+    const text = editorRef.current?.getValue() ?? '';
+    onSubmit(text);
+  }
+  function handleCancel() {
+    editorRef.current?.setValue('');
+    onOpenChange({ open: false });
+  }
+  useLayoutEffect(() => {
+    handleSubmitRef.current = handleSubmit;
+    handleCancelRef.current = handleCancel;
+  });
+
+  // open または initialValue が変化したとき、既にマウント済みのエディタに反映
+  useEffect(() => {
+    if (open && editorRef.current) {
+      editorRef.current.setValue(initialValue ?? '');
+      // カーソルを先頭に移動してフォーカス
+      editorRef.current.setPosition({ lineNumber: 1, column: 1 });
+      editorRef.current.focus();
+    }
+  }, [open, initialValue]);
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(details) => {
+        if (!details.open) {
+          editorRef.current?.setValue('');
+          onOpenChange(details);
+        }
+      }}
+      title={title}
+      maxWidth="xl"
+      showCloseButton={true}
+      trapFocus={false}
+    >
+      <div className="space-y-4">
+        <div className="border border-theme rounded overflow-hidden" style={{ height: '300px' }}>
+          <Editor
+            height="300px"
+            defaultLanguage="plaintext"
+            defaultValue=""
+            onMount={(editorInstance, monacoInstance) => {
+              editorRef.current = editorInstance;
+              // 初期コンテンツをセットしカーソルを先頭に
+              editorInstance.setValue(initialValue ?? '');
+              editorInstance.setPosition({ lineNumber: 1, column: 1 });
+              editorInstance.focus();
+              editorInstance.onKeyDown((e) => {
+                // Cmd/Ctrl+Enter: 送信
+                if (e.keyCode === monacoInstance.KeyCode.Enter && (e.metaKey || e.ctrlKey)) {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  handleSubmitRef.current();
+                }
+                // Esc: キャンセル（Monaco がイベントを消費するため明示的に処理）
+                if (e.keyCode === monacoInstance.KeyCode.Escape) {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  handleCancelRef.current();
+                }
+              });
+            }}
+            options={{
+              minimap: { enabled: false },
+              lineNumbers: 'on',
+              wordWrap: 'on',
+              fontSize: 13,
+              scrollBeyondLastLine: false,
+            }}
+            theme={effectiveTheme === 'dark' ? 'vs-dark' : 'vs-light'}
+          />
+        </div>
+        <p className="text-xs text-theme-muted">
+          {isMac ? 'Cmd+Enter' : 'Ctrl+Enter'} で{submitLabel}、Esc でキャンセル
+        </p>
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={handleCancel}
+            className="px-4 py-2 border border-theme rounded text-theme-fg hover:bg-theme-hover cursor-pointer"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSubmit}
+            className="px-4 py-2 bg-primary text-white rounded hover:bg-primary-hover cursor-pointer"
+          >
+            {submitLabel}
+          </button>
+        </div>
+      </div>
+    </Dialog>
+  );
+}

--- a/src/components/MonacoEditorModal.tsx
+++ b/src/components/MonacoEditorModal.tsx
@@ -81,6 +81,7 @@ export function MonacoEditorModal({
       maxWidth="xl"
       showCloseButton={true}
       trapFocus={false}
+      restoreFocus={false}
     >
       <div className="space-y-4">
         <div className="border border-theme rounded overflow-hidden" style={{ height: '300px' }}>

--- a/src/components/MonacoEditorModal.tsx
+++ b/src/components/MonacoEditorModal.tsx
@@ -78,15 +78,18 @@ export function MonacoEditorModal({
         }
       }}
       title={title}
-      maxWidth="xl"
+      maxWidth="4xl"
       showCloseButton={true}
       trapFocus={false}
       restoreFocus={false}
     >
       <div className="space-y-4">
-        <div className="border border-theme rounded overflow-hidden" style={{ height: '300px' }}>
+        <div
+          className="border border-theme rounded overflow-hidden"
+          style={{ height: 'clamp(200px, 50vh, 600px)' }}
+        >
           <Editor
-            height="300px"
+            height="100%"
             defaultLanguage="plaintext"
             defaultValue=""
             onMount={(editorInstance, monacoInstance) => {

--- a/src/components/SessionTabs.tsx
+++ b/src/components/SessionTabs.tsx
@@ -126,17 +126,14 @@ export function SessionTabs({
   );
 
   // アクティブタブのインジケーター位置を更新
+  // offsetLeft/offsetWidth を使用（position:absolute の参照座標と一致し、スクロール時もズレない）
   useEffect(() => {
     const activeIndex = tabs.findIndex((t) => t.tab_id === activeTabId);
     if (activeIndex !== -1 && tabRefs.current[activeIndex]) {
       const tabElement = tabRefs.current[activeIndex];
       if (tabElement) {
-        const containerLeft = tabElement.parentElement?.getBoundingClientRect().left || 0;
-        const tabLeft = tabElement.getBoundingClientRect().left;
-        const relativeLeft = tabLeft - containerLeft;
-
         setIndicatorStyle({
-          left: relativeLeft,
+          left: tabElement.offsetLeft,
           width: tabElement.offsetWidth,
         });
       }

--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -74,6 +74,14 @@ export const TerminalPanel = forwardRef<TerminalPanelHandle, TerminalPanelProps>
     // 各TerminalViewへのrefマップ
     const terminalRefs = useRef<Map<string, TerminalViewHandle>>(new Map());
 
+    // アクティブタブが変わったら xterm にフォーカスを移す
+    // TerminalPanel の effect は子コンポーネントの effects より後に実行されるため、
+    // termRef.current が確実に設定済みの状態でフォーカスできる
+    useEffect(() => {
+      if (!activeTabId) return;
+      terminalRefs.current.get(activeTabId)?.focus();
+    }, [activeTabId]);
+
     const handleStatusChange = useCallback(
       (tabId: string, terminal: TerminalStatus, claude: ClaudeStatus) => {
         setTabStatusMap((prev) => {

--- a/src/components/TerminalPanel.tsx
+++ b/src/components/TerminalPanel.tsx
@@ -182,8 +182,9 @@ export const TerminalPanel = forwardRef<TerminalPanelHandle, TerminalPanelProps>
           )}
         </div>
 
-        {/* TerminalViewエリア（display:none方式で複数を保持） */}
-        <div className="flex-1 min-h-0 px-4 pb-4 pt-2">
+        {/* TerminalViewエリア（visibility:hidden方式で複数を保持） */}
+        {/* absolute で全タブを重ねることで、visibility:hidden のタブが空白として残らないようにする */}
+        <div className="flex-1 min-h-0 relative">
           {tabs.map((tab) => {
             const isMounted = mountedTabIds.has(tab.tab_id);
             const isActive = tab.tab_id === activeTabId;
@@ -193,8 +194,11 @@ export const TerminalPanel = forwardRef<TerminalPanelHandle, TerminalPanelProps>
             return (
               <div
                 key={tab.tab_id}
-                style={{ display: isActive ? 'flex' : 'none' }}
-                className="h-full flex-col"
+                className="absolute inset-0 flex flex-col px-4 pb-4 pt-2"
+                style={{
+                  visibility: isActive ? 'visible' : 'hidden',
+                  pointerEvents: isActive ? 'auto' : 'none',
+                }}
               >
                 <TerminalView
                   ref={(handle) => {
@@ -205,6 +209,7 @@ export const TerminalPanel = forwardRef<TerminalPanelHandle, TerminalPanelProps>
                     }
                   }}
                   tabId={tab.tab_id}
+                  isActive={isActive}
                   cwd={task.worktreePath}
                   worktreePath={task.worktreePath}
                   command={

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -1,6 +1,14 @@
 'use client';
 
-import { useEffect, useRef, useState, useCallback, useImperativeHandle, forwardRef } from 'react';
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  useCallback,
+  useImperativeHandle,
+  forwardRef,
+} from 'react';
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import '@xterm/xterm/css/xterm.css';
@@ -79,6 +87,7 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
   // EditorSessionProvider 経由（Ctrl+G）でエディタが開いているかを追跡するref。
   // xterm の customKeyEventHandler（_keyUp内のfocus再取得）から参照する。
   const isExternalEditorOpenRef = useRef(false);
+  const isActiveRef = useRef(isActive);
   // reused接続時、リングバッファ受信後にsendResize()するまでuseEffectからのsendResizeを抑制
   const suppressResizeRef = useRef(false);
   const [status, setStatus] = useState<TerminalStatus>('idle');
@@ -111,6 +120,10 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
     onStatusChangeRef.current?.(tabId, status, claudeStatus);
   }, [tabId, status, claudeStatus]);
 
+  useLayoutEffect(() => {
+    isActiveRef.current = isActive;
+  });
+
   // アクティブになったタイミングで xterm にフォーカスを当てる
   // タブヘッダーのクリックでは xterm の mousedown handler が呼ばれないため明示的にフォーカスする
   useEffect(() => {
@@ -120,12 +133,15 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
 
   // Editor Modal の開閉に合わせてフォーカスを制御
   // 開く: xterm を blur → Monaco がフォーカスを取得できるようにする
-  // 閉じる: xterm にフォーカスを戻す
+  // 閉じる: Dialog close 処理完了後に xterm にフォーカスを戻す
   useEffect(() => {
     if (showEditorModal) {
       termRef.current?.blur();
     } else if (isActive) {
-      termRef.current?.focus();
+      const textarea = containerRef.current?.querySelector<HTMLTextAreaElement>(
+        'textarea.xterm-helper-textarea'
+      );
+      textarea?.focus();
     }
   }, [showEditorModal, isActive]);
 
@@ -221,6 +237,13 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
       if (socket?.connected && sid) {
         socket.emit('input', { sessionId: sid, data: '\x0c' });
       }
+      // アクティブタブのみフォーカスを復帰する
+      if (!isActiveRef.current) return;
+      // xterm 内の textarea を直接 focus する（Terminal.focus() では効かない）
+      const textarea = containerRef.current?.querySelector<HTMLTextAreaElement>(
+        'textarea.xterm-helper-textarea'
+      );
+      textarea?.focus();
     }
     window.addEventListener('editor-session-open', handleEditorSessionOpen);
     window.addEventListener('editor-session-done', handleEditorSessionDone);

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -76,6 +76,9 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
   const sessionIdRef = useRef<string | null>(tabId);
   const unmountedRef = useRef(false);
   const [showEditorModal, setShowEditorModal] = useState(false);
+  // EditorSessionProvider 経由（Ctrl+G）でエディタが開いているかを追跡するref。
+  // xterm の customKeyEventHandler（_keyUp内のfocus再取得）から参照する。
+  const isExternalEditorOpenRef = useRef(false);
   // reused接続時、リングバッファ受信後にsendResize()するまでuseEffectからのsendResizeを抑制
   const suppressResizeRef = useRef(false);
   const [status, setStatus] = useState<TerminalStatus>('idle');
@@ -157,6 +160,13 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
     termRef.current = term;
     fitAddonRef.current = fitAddon;
 
+    // エディタモーダルが開いている間は xterm の _keyUp が this.focus() を呼んでフォーカスを
+    // 奪い返すのを防ぐ。customKeyEventHandler が false を返すと _keyUp が早期リターンする。
+    term.attachCustomKeyEventHandler(() => {
+      if (isExternalEditorOpenRef.current) return false;
+      return true;
+    });
+
     // xterm.js は CompositionHelper 内で composition 中のキーストロークを内部で抑制し、
     // compositionend 後の setTimeout で確定テキストのみ triggerDataEvent → onData で通知する。
     // そのため我々が compositionstart/end を監視して onData をガードする必要はない。
@@ -195,17 +205,29 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
     }
   }, [isDark]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // エディタセッション完了後に Ctrl+L を送信して Claude Code に再描画させる
+  // エディタセッション開閉イベント（EditorSessionProvider → TerminalView 通知）
   useEffect(() => {
+    function handleEditorSessionOpen() {
+      // xterm の _keyUp による focus 再取得を防ぐフラグを立てる
+      isExternalEditorOpenRef.current = true;
+      // xterm から明示的に blur して Monaco がフォーカスを取得できるようにする
+      termRef.current?.blur();
+    }
     function handleEditorSessionDone() {
+      isExternalEditorOpenRef.current = false;
+      // Ctrl+L で Claude Code に再描画させる
       const socket = socketRef.current;
       const sid = sessionIdRef.current;
       if (socket?.connected && sid) {
         socket.emit('input', { sessionId: sid, data: '\x0c' });
       }
     }
+    window.addEventListener('editor-session-open', handleEditorSessionOpen);
     window.addEventListener('editor-session-done', handleEditorSessionDone);
-    return () => window.removeEventListener('editor-session-done', handleEditorSessionDone);
+    return () => {
+      window.removeEventListener('editor-session-open', handleEditorSessionOpen);
+      window.removeEventListener('editor-session-done', handleEditorSessionDone);
+    };
   }, []);
 
   function sendResize() {

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -36,6 +36,8 @@ interface TerminalViewProps {
   className?: string;
   /** Todoリスト更新時のコールバック（KanbanカードのProgress Bar用） */
   onTodosUpdated?: (tabId: string, todos: Todo[]) => void;
+  /** タブがアクティブかどうか（フォーカス制御用） */
+  isActive?: boolean;
   /** terminal/claudeステータス変化時のコールバック（タブ表示用） */
   onStatusChange?: (
     tabId: string,
@@ -51,7 +53,17 @@ export interface TerminalViewHandle {
 }
 
 export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(function TerminalView(
-  { tabId, cwd, env, worktreePath, command, className = '', onTodosUpdated, onStatusChange },
+  {
+    tabId,
+    cwd,
+    env,
+    worktreePath,
+    command,
+    className = '',
+    isActive,
+    onTodosUpdated,
+    onStatusChange,
+  },
   ref
 ) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -92,6 +104,13 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
   useEffect(() => {
     onStatusChangeRef.current?.(tabId, status, claudeStatus);
   }, [tabId, status, claudeStatus]);
+
+  // アクティブになったタイミングで xterm にフォーカスを当てる
+  // タブヘッダーのクリックでは xterm の mousedown handler が呼ばれないため明示的にフォーカスする
+  useEffect(() => {
+    if (!isActive) return;
+    termRef.current?.focus();
+  }, [isActive]);
 
   // connected になったタイミングで fit() を再呼び出し（オーバーレイ消滅後のサイズ確定）
   useEffect(() => {

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -6,7 +6,8 @@ import { FitAddon } from '@xterm/addon-fit';
 import '@xterm/xterm/css/xterm.css';
 import { io, type Socket } from 'socket.io-client';
 import { useTheme } from '@/contexts/ThemeContext';
-import { Loader2, Copy, Play, Check } from 'lucide-react';
+import { Loader2, Copy, Play, Check, SquarePen } from 'lucide-react';
+import { MonacoEditorModal } from '@/components/MonacoEditorModal';
 
 const FASTIFY_API_BASE = 'http://localhost:2792';
 
@@ -50,6 +51,8 @@ interface TerminalViewProps {
 export interface TerminalViewHandle {
   /** PTYにテキストを書き込む（末尾改行は自動付加しない） */
   sendInput: (data: string) => void;
+  /** xterm.js にフォーカスを当てる */
+  focus: () => void;
 }
 
 export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(function TerminalView(
@@ -71,10 +74,10 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
   const fitAddonRef = useRef<FitAddon | null>(null);
   const socketRef = useRef<Socket | null>(null);
   const sessionIdRef = useRef<string | null>(tabId);
+  const unmountedRef = useRef(false);
+  const [showEditorModal, setShowEditorModal] = useState(false);
   // reused接続時、リングバッファ受信後にsendResize()するまでuseEffectからのsendResizeを抑制
   const suppressResizeRef = useRef(false);
-  // IME composition中（日本語変換中）はPTYへの入力を抑制する
-  const isComposingRef = useRef(false);
   const [status, setStatus] = useState<TerminalStatus>('idle');
   const [claudeStatus, setClaudeStatus] = useState<ClaudeStatus>('idle');
   const [todos, setTodos] = useState<Todo[]>([]);
@@ -112,6 +115,17 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
     termRef.current?.focus();
   }, [isActive]);
 
+  // Editor Modal の開閉に合わせてフォーカスを制御
+  // 開く: xterm を blur → Monaco がフォーカスを取得できるようにする
+  // 閉じる: xterm にフォーカスを戻す
+  useEffect(() => {
+    if (showEditorModal) {
+      termRef.current?.blur();
+    } else if (isActive) {
+      termRef.current?.focus();
+    }
+  }, [showEditorModal, isActive]);
+
   // connected になったタイミングで fit() を再呼び出し（オーバーレイ消滅後のサイズ確定）
   useEffect(() => {
     if (status === 'connected' && fitAddonRef.current) {
@@ -143,19 +157,9 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
     termRef.current = term;
     fitAddonRef.current = fitAddon;
 
-    // IME composition中はPTYへの入力を抑制する
-    // xterm.js の内部 textarea に compositionstart/end を登録する
-    const textarea = containerRef.current.querySelector('textarea');
-    const onCompositionStart = () => {
-      isComposingRef.current = true;
-    };
-    const onCompositionEnd = () => {
-      isComposingRef.current = false;
-    };
-    if (textarea) {
-      textarea.addEventListener('compositionstart', onCompositionStart);
-      textarea.addEventListener('compositionend', onCompositionEnd);
-    }
+    // xterm.js は CompositionHelper 内で composition 中のキーストロークを内部で抑制し、
+    // compositionend 後の setTimeout で確定テキストのみ triggerDataEvent → onData で通知する。
+    // そのため我々が compositionstart/end を監視して onData をガードする必要はない。
 
     const observer = new ResizeObserver(() => {
       fitAddon.fit();
@@ -175,10 +179,6 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
     return () => {
       abortController.abort();
       observer.disconnect();
-      if (textarea) {
-        textarea.removeEventListener('compositionstart', onCompositionStart);
-        textarea.removeEventListener('compositionend', onCompositionEnd);
-      }
       term.dispose();
       termRef.current = null;
       fitAddonRef.current = null;
@@ -194,6 +194,19 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
       termRef.current.options.theme = xtermTheme;
     }
   }, [isDark]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // エディタセッション完了後に Ctrl+L を送信して Claude Code に再描画させる
+  useEffect(() => {
+    function handleEditorSessionDone() {
+      const socket = socketRef.current;
+      const sid = sessionIdRef.current;
+      if (socket?.connected && sid) {
+        socket.emit('input', { sessionId: sid, data: '\x0c' });
+      }
+    }
+    window.addEventListener('editor-session-done', handleEditorSessionDone);
+    return () => window.removeEventListener('editor-session-done', handleEditorSessionDone);
+  }, []);
 
   function sendResize() {
     const socket = socketRef.current;
@@ -211,6 +224,9 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
       if (socket?.connected && sid) {
         socket.emit('input', { sessionId: sid, data });
       }
+    },
+    focus: () => {
+      termRef.current?.focus();
     },
   }));
 
@@ -337,8 +353,6 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
     });
 
     term.onData((data) => {
-      // IME composition中（日本語変換中）はPTYに送信しない
-      if (isComposingRef.current) return;
       if (socket.connected && sessionIdRef.current) {
         socket.emit('input', { sessionId: sessionIdRef.current, data });
       }
@@ -380,88 +394,124 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
   const shortTabId = tabId.length > 8 ? `${tabId.slice(0, 8)}…` : tabId;
 
   return (
-    <div className={`flex flex-col h-full min-h-0 ${className}`}>
-      {/* UUID表示バー */}
-      <div className="flex items-center gap-2 px-2 py-1 border-b border-theme flex-shrink-0 bg-theme-card">
-        <span className="font-mono text-xs text-theme-muted" title={tabId}>
-          {shortTabId}
-        </span>
-        <button
-          onClick={handleCopyTabId}
-          className="p-1 text-theme-muted hover:text-theme-fg rounded hover:bg-theme-hover cursor-pointer"
-          title="Copy tab ID"
-        >
-          {copied ? <Check className="w-3 h-3 text-green-500" /> : <Copy className="w-3 h-3" />}
-        </button>
-        <button
-          onClick={handleRunClaude}
-          disabled={!isConnected}
-          className={`flex items-center gap-1 text-xs px-2 py-0.5 rounded cursor-pointer ${
-            isConnected
-              ? 'bg-primary text-white hover:opacity-80'
-              : 'bg-theme-hover text-theme-muted cursor-not-allowed opacity-50'
-          }`}
-          title="Run Claude"
-        >
-          <Play className="w-3 h-3" />
-          Run Claude
-        </button>
-      </div>
+    <>
+      <div className={`flex flex-col h-full min-h-0 ${className}`}>
+        {/* UUID表示バー */}
+        <div className="flex items-center gap-2 px-2 py-1 border-b border-theme flex-shrink-0 bg-theme-card">
+          <span className="font-mono text-xs text-theme-muted" title={tabId}>
+            {shortTabId}
+          </span>
+          <button
+            onClick={handleCopyTabId}
+            className="p-1 text-theme-muted hover:text-theme-fg rounded hover:bg-theme-hover cursor-pointer"
+            title="Copy tab ID"
+          >
+            {copied ? <Check className="w-3 h-3 text-green-500" /> : <Copy className="w-3 h-3" />}
+          </button>
+          <button
+            onClick={handleRunClaude}
+            disabled={!isConnected}
+            className={`flex items-center gap-1 text-xs px-2 py-0.5 rounded cursor-pointer ${
+              isConnected
+                ? 'bg-primary text-white hover:opacity-80'
+                : 'bg-theme-hover text-theme-muted cursor-not-allowed opacity-50'
+            }`}
+            title="Run Claude"
+          >
+            <Play className="w-3 h-3" />
+            Run Claude
+          </button>
+          <button
+            onClick={() => setShowEditorModal(true)}
+            disabled={!isConnected}
+            className={`flex items-center gap-1 text-xs px-2 py-0.5 rounded cursor-pointer ${
+              isConnected
+                ? 'text-theme-muted hover:bg-theme-hover hover:text-theme-fg'
+                : 'text-theme-muted cursor-not-allowed opacity-50'
+            }`}
+            title="Open editor input"
+          >
+            <SquarePen className="w-3 h-3" />
+            Open Editor
+          </button>
+        </div>
 
-      {/* Terminal エリア: xterm コンテナは常にDOMに存在（マウント要件）、接続中はオーバーレイで隠す */}
-      <div className="relative flex-1 min-h-0 overflow-hidden">
-        <div ref={containerRef} className="w-full h-full" style={{ padding: '4px' }} />
+        {/* Terminal エリア: xterm コンテナは常にDOMに存在（マウント要件）、接続中はオーバーレイで隠す */}
+        <div className="relative flex-1 min-h-0 overflow-hidden">
+          <div ref={containerRef} className="w-full h-full" style={{ padding: '4px' }} />
 
-        {/* 接続中オーバーレイ: connected になると消える */}
-        {isConnecting && (
-          <div className="absolute inset-0 flex items-center justify-center bg-theme-bg">
-            <div className="flex items-center gap-2 text-theme-muted text-xs">
-              <Loader2 className="w-4 h-4 animate-spin" />
-              <span>Connecting...</span>
-            </div>
-          </div>
-        )}
-
-        {/* exited / error: overlayで再接続を促す */}
-        {isPausedOrExited && (
-          <div className="absolute inset-0 flex items-center justify-center bg-theme-bg/90">
-            <div className="text-center space-y-2">
-              {status === 'error' && <p className="text-xs text-red-500">Connection failed</p>}
-              {status === 'exited' && <p className="text-xs text-theme-muted">Session ended</p>}
-              {status === 'paused' && <p className="text-xs text-theme-muted">Paused</p>}
-              <button
-                onClick={reconnectSession}
-                className="text-xs px-3 py-1.5 rounded bg-primary text-white hover:opacity-80 cursor-pointer"
-              >
-                Reconnect
-              </button>
-            </div>
-          </div>
-        )}
-
-        {/* Todo進捗（running時かつtodosがある場合のみ表示） */}
-        {showTodoProgress && (
-          <div className="absolute bottom-0 left-0 right-0 px-2 py-1 bg-theme-card/90 border-t border-theme">
-            <div className="flex items-center gap-2">
-              <div className="flex-1 bg-theme-hover rounded-full h-1 overflow-hidden">
-                <div
-                  className="h-full bg-primary transition-all duration-300"
-                  style={{ width: `${totalTodos > 0 ? (completedTodos / totalTodos) * 100 : 0}%` }}
-                />
+          {/* 接続中オーバーレイ: connected になると消える */}
+          {isConnecting && (
+            <div className="absolute inset-0 flex items-center justify-center bg-theme-bg">
+              <div className="flex items-center gap-2 text-theme-muted text-xs">
+                <Loader2 className="w-4 h-4 animate-spin" />
+                <span>Connecting...</span>
               </div>
-              <span className="text-[10px] text-theme-muted flex-shrink-0">
-                {completedTodos}/{totalTodos}
-              </span>
             </div>
-            {/* 現在in_progressのtodo */}
-            {todos.find((t) => t.status === 'in_progress') && (
-              <p className="text-[10px] text-theme-muted truncate mt-0.5">
-                {todos.find((t) => t.status === 'in_progress')?.content}
-              </p>
-            )}
-          </div>
-        )}
+          )}
+
+          {/* exited / error: overlayで再接続を促す */}
+          {isPausedOrExited && (
+            <div className="absolute inset-0 flex items-center justify-center bg-theme-bg/90">
+              <div className="text-center space-y-2">
+                {status === 'error' && <p className="text-xs text-red-500">Connection failed</p>}
+                {status === 'exited' && <p className="text-xs text-theme-muted">Session ended</p>}
+                {status === 'paused' && <p className="text-xs text-theme-muted">Paused</p>}
+                <button
+                  onClick={reconnectSession}
+                  className="text-xs px-3 py-1.5 rounded bg-primary text-white hover:opacity-80 cursor-pointer"
+                >
+                  Reconnect
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* Todo進捗（running時かつtodosがある場合のみ表示） */}
+          {showTodoProgress && (
+            <div className="absolute bottom-0 left-0 right-0 px-2 py-1 bg-theme-card/90 border-t border-theme">
+              <div className="flex items-center gap-2">
+                <div className="flex-1 bg-theme-hover rounded-full h-1 overflow-hidden">
+                  <div
+                    className="h-full bg-primary transition-all duration-300"
+                    style={{
+                      width: `${totalTodos > 0 ? (completedTodos / totalTodos) * 100 : 0}%`,
+                    }}
+                  />
+                </div>
+                <span className="text-[10px] text-theme-muted flex-shrink-0">
+                  {completedTodos}/{totalTodos}
+                </span>
+              </div>
+              {/* 現在in_progressのtodo */}
+              {todos.find((t) => t.status === 'in_progress') && (
+                <p className="text-[10px] text-theme-muted truncate mt-0.5">
+                  {todos.find((t) => t.status === 'in_progress')?.content}
+                </p>
+              )}
+            </div>
+          )}
+        </div>
       </div>
-    </div>
+
+      {/* Editor Input Modal */}
+      <MonacoEditorModal
+        open={showEditorModal}
+        onOpenChange={(details) => {
+          if (!details.open) setShowEditorModal(false);
+        }}
+        onSubmit={(text) => {
+          // term.paste() を使うことで xterm の Bracketed Paste Mode を自動処理する。
+          // bracketedPasteMode ON（Claude Code等）: \x1b[200~...\x1b[201~ でラップして改行をそのまま挿入
+          // bracketedPasteMode OFF（通常シェル）: \r?\n → \r に変換（xterm 内部処理）
+          if (termRef.current && text) {
+            termRef.current.paste(text);
+          }
+          setShowEditorModal(false);
+        }}
+        title="Terminal Input"
+        submitLabel="Paste"
+      />
+    </>
   );
 });

--- a/src/components/ui/Dialog.tsx
+++ b/src/components/ui/Dialog.tsx
@@ -11,6 +11,10 @@ interface DialogProps {
   children: ReactNode;
   maxWidth?: 'sm' | 'md' | 'lg' | 'xl' | '2xl';
   showCloseButton?: boolean;
+  /** ダイアログを開いた時に最初にフォーカスする要素を返す関数 */
+  initialFocusEl?: () => HTMLElement | null;
+  /** フォーカストラップを有効にするか（デフォルト: true） */
+  trapFocus?: boolean;
 }
 
 const maxWidthClasses = {
@@ -28,9 +32,17 @@ export function Dialog({
   children,
   maxWidth = '2xl',
   showCloseButton = true,
+  initialFocusEl,
+  trapFocus = true,
 }: DialogProps) {
   return (
-    <ArkDialog.Root open={open} onOpenChange={onOpenChange} modal trapFocus>
+    <ArkDialog.Root
+      open={open}
+      onOpenChange={onOpenChange}
+      modal
+      trapFocus={trapFocus}
+      initialFocusEl={initialFocusEl}
+    >
       <ArkDialog.Backdrop className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50" />
       <ArkDialog.Positioner className="fixed inset-0 z-50 flex items-center justify-center p-4">
         <ArkDialog.Content

--- a/src/components/ui/Dialog.tsx
+++ b/src/components/ui/Dialog.tsx
@@ -15,6 +15,8 @@ interface DialogProps {
   initialFocusEl?: () => HTMLElement | null;
   /** フォーカストラップを有効にするか（デフォルト: true） */
   trapFocus?: boolean;
+  /** ダイアログを閉じた時にフォーカスを元の要素に戻すか（デフォルト: true） */
+  restoreFocus?: boolean;
 }
 
 const maxWidthClasses = {
@@ -34,6 +36,7 @@ export function Dialog({
   showCloseButton = true,
   initialFocusEl,
   trapFocus = true,
+  restoreFocus = true,
 }: DialogProps) {
   return (
     <ArkDialog.Root
@@ -41,6 +44,7 @@ export function Dialog({
       onOpenChange={onOpenChange}
       modal
       trapFocus={trapFocus}
+      restoreFocus={restoreFocus}
       initialFocusEl={initialFocusEl}
     >
       <ArkDialog.Backdrop className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50" />

--- a/src/components/ui/Dialog.tsx
+++ b/src/components/ui/Dialog.tsx
@@ -9,7 +9,7 @@ interface DialogProps {
   onOpenChange: (details: { open: boolean }) => void;
   title?: ReactNode;
   children: ReactNode;
-  maxWidth?: 'sm' | 'md' | 'lg' | 'xl' | '2xl';
+  maxWidth?: 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '4xl' | '6xl';
   showCloseButton?: boolean;
   /** ダイアログを開いた時に最初にフォーカスする要素を返す関数 */
   initialFocusEl?: () => HTMLElement | null;
@@ -25,6 +25,8 @@ const maxWidthClasses = {
   lg: 'max-w-lg',
   xl: 'max-w-xl',
   '2xl': 'max-w-2xl',
+  '4xl': 'max-w-4xl',
+  '6xl': 'max-w-6xl',
 };
 
 export function Dialog({
@@ -55,7 +57,7 @@ export function Dialog({
           {(title || showCloseButton) && (
             <div className="flex items-center justify-between p-6 pb-4">
               {title && (
-                <ArkDialog.Title className="text-xl font-bold text-theme-fg">
+                <ArkDialog.Title className="text-base font-semibold text-theme-fg">
                   {title}
                 </ArkDialog.Title>
               )}


### PR DESCRIPTION
xterm.js 6.x が IntersectionObserver で display:none を検知すると レンダリングを自動停止（_isPaused=true）するため、タブ切り替え後に
クリックしても入力できない状態になっていた。

display:none/flex → visibility:hidden/visible + pointer-events に変更し、 IntersectionObserver を発火させないことで常時レンダリングを維持する。
全タブを absolute で重ねることで visibility:hidden による空白エリアを防ぐ。

また isActive プロップを追加し、タブ切り替え時に term.focus() を呼ぶことで
タブヘッダークリック後も即入力できるようにした。