### PR TITLE
feat: Claude Code Plugin導入 — hooks/MCP/skillsをpluginとして一元管理

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "tsx scripts/auto-migrate.ts && concurrently --kill-others --names \"next,fastify\" --prefix-colors \"blue,green\" \"next dev -p 2791\" \"tsx watch server/index.ts\"",
+    "dev": "tsx scripts/auto-migrate.ts && tsx scripts/with-plugin.ts dev",
     "server:dev": "tsx watch server/index.ts",
     "build": "prisma generate && next build",
-    "start": "tsx scripts/auto-migrate.ts && concurrently --kill-others --names \"next,fastify\" --prefix-colors \"blue,green\" \"next start -p 2791\" \"tsx server/index.ts\"",
+    "start": "tsx scripts/auto-migrate.ts && tsx scripts/with-plugin.ts start",
     "postinstall": "prisma generate && chmod +x node_modules/node-pty/prebuilds/*/spawn-helper 2>/dev/null || true",
     "lint": "eslint",
     "format": "prettier --write .",

--- a/scripts/with-plugin.ts
+++ b/scripts/with-plugin.ts
@@ -1,0 +1,171 @@
+import { execSync, spawn } from 'child_process';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+
+const MARKETPLACE_DIR = path.resolve(__dirname, '..', 'tsunagi-marketplace');
+const MARKETPLACE_NAME = 'tsunagi-marketplace';
+const PLUGIN_REF = `tsunagi-plugin@${MARKETPLACE_NAME}`;
+
+let cleanedUp = false;
+
+function log(msg: string) {
+  console.log(`[with-plugin] ${msg}`);
+}
+
+function runClaude(args: string): boolean {
+  try {
+    execSync(`claude ${args}`, { stdio: 'pipe' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * marketplace を登録する
+ * CLI: `claude plugin marketplace add ./tsunagi-marketplace`
+ * フォールバック: ~/.claude/settings.json の extraKnownMarketplaces に直接書き込み
+ */
+function addMarketplace(): boolean {
+  // まず CLI コマンドを試行
+  if (runClaude(`plugin marketplace add ${MARKETPLACE_DIR}`)) {
+    log('Marketplace added via CLI');
+    return true;
+  }
+
+  // フォールバック: settings.json に直接書き込み
+  log('CLI marketplace add failed, falling back to settings.json');
+  const settingsPath = path.join(os.homedir(), '.claude', 'settings.json');
+
+  let settings: Record<string, unknown> = {};
+  if (fs.existsSync(settingsPath)) {
+    try {
+      settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8')) as Record<string, unknown>;
+    } catch {
+      // パースエラーは無視
+    }
+  }
+
+  const marketplaces = (settings.extraKnownMarketplaces ?? {}) as Record<string, unknown>;
+  marketplaces[MARKETPLACE_NAME] = { source: MARKETPLACE_DIR };
+  settings.extraKnownMarketplaces = marketplaces;
+
+  fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+  fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2), 'utf-8');
+  log('Marketplace added via settings.json');
+  return true;
+}
+
+/**
+ * marketplace 登録を削除する
+ */
+function removeMarketplace(): void {
+  // CLI で削除を試行
+  if (runClaude(`plugin marketplace remove ${MARKETPLACE_NAME}`)) {
+    return;
+  }
+
+  // フォールバック: settings.json から削除
+  const settingsPath = path.join(os.homedir(), '.claude', 'settings.json');
+  if (!fs.existsSync(settingsPath)) return;
+
+  try {
+    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8')) as Record<string, unknown>;
+    const marketplaces = settings.extraKnownMarketplaces as Record<string, unknown> | undefined;
+    if (marketplaces && MARKETPLACE_NAME in marketplaces) {
+      delete marketplaces[MARKETPLACE_NAME];
+      if (Object.keys(marketplaces).length === 0) {
+        delete settings.extraKnownMarketplaces;
+      }
+      fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2), 'utf-8');
+    }
+  } catch {
+    // 無視
+  }
+}
+
+function installPlugin(): boolean {
+  if (runClaude(`plugin install ${PLUGIN_REF} --scope user`)) {
+    log('Plugin installed');
+    return true;
+  }
+  log('Plugin install failed');
+  return false;
+}
+
+function uninstallPlugin(): boolean {
+  if (runClaude(`plugin uninstall ${PLUGIN_REF}`)) {
+    log('Plugin uninstalled');
+    return true;
+  }
+  log('Plugin uninstall failed');
+  return false;
+}
+
+function cleanup() {
+  if (cleanedUp) return;
+  cleanedUp = true;
+
+  log('Cleaning up...');
+  uninstallPlugin();
+  removeMarketplace();
+  log('Cleanup complete');
+}
+
+// --- main ---
+
+const mode = process.argv[2];
+if (mode !== 'dev' && mode !== 'start') {
+  console.error('Usage: tsx scripts/with-plugin.ts <dev|start>');
+  process.exit(1);
+}
+
+// 1. marketplace 登録 & plugin install
+addMarketplace();
+installPlugin();
+
+// 2. シグナルハンドラ登録
+process.on('SIGINT', () => {
+  cleanup();
+  process.exit(0);
+});
+process.on('SIGTERM', () => {
+  cleanup();
+  process.exit(0);
+});
+process.on('exit', () => {
+  cleanup();
+});
+process.on('uncaughtException', (err) => {
+  console.error('[with-plugin] Uncaught exception:', err);
+  cleanup();
+  process.exit(1);
+});
+
+// 3. concurrently でサーバー起動
+const nextCmd = mode === 'dev' ? 'next dev -p 2791' : 'next start -p 2791';
+const fastifyCmd = mode === 'dev' ? 'tsx watch server/index.ts' : 'tsx server/index.ts';
+
+const child = spawn(
+  'npx',
+  [
+    'concurrently',
+    '--kill-others',
+    '--names',
+    'next,fastify',
+    '--prefix-colors',
+    'blue,green',
+    `"${nextCmd}"`,
+    `"${fastifyCmd}"`,
+  ],
+  {
+    stdio: 'inherit',
+    shell: true,
+  }
+);
+
+child.on('exit', (code) => {
+  cleanup();
+  process.exit(code ?? 0);
+});

--- a/server/routes/mcp.ts
+++ b/server/routes/mcp.ts
@@ -2,11 +2,76 @@ import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import * as os from 'os';
+import * as path from 'path';
 import { prisma } from '../../src/lib/db.js';
 import { todoStore } from '../todo-store.js';
 
 /** SSEセッションIDをキーにしたtransportのMap */
 const transports = new Map<string, SSEServerTransport>();
+
+const WORKSPACES_ROOT = path.join(os.homedir(), '.tsunagi', 'workspaces');
+
+/** CWDからowner/repo/branchを抽出する */
+function parseWorktreePath(cwd: string): { owner: string; repo: string; branch: string } | null {
+  // ~/.tsunagi/workspaces/{owner}/{repo}/{normalized-branch}
+  const relative = path.relative(WORKSPACES_ROOT, cwd);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) return null;
+
+  const parts = relative.split(path.sep);
+  if (parts.length < 3) return null;
+
+  return { owner: parts[0], repo: parts[1], branch: parts[2] };
+}
+
+/** id / session_id / cwd からタスクを解決する共通ヘルパー */
+async function resolveTask(args: { id?: string; session_id?: string; cwd?: string }) {
+  // 1. id指定: 直接タスクを取得
+  if (args.id) {
+    return prisma.task.findUnique({
+      where: { id: args.id },
+      include: { tabs: true },
+    });
+  }
+  // 2. session_id指定: session_id = tabId → Tab.taskId → Task
+  if (args.session_id) {
+    const tab = await prisma.tab.findUnique({ where: { tabId: args.session_id } });
+    if (!tab) return null;
+    return prisma.task.findUnique({
+      where: { id: tab.taskId },
+      include: { tabs: true },
+    });
+  }
+  // 3. cwd指定: パスからowner/repo/branchを抽出してタスクを検索
+  if (args.cwd) {
+    const parsed = parseWorktreePath(args.cwd);
+    if (!parsed) return null;
+    // normalized branch名でマッチするタスクを探す
+    // branch名はDB上では "feat/xxx" 形式、worktreeパスでは "feat-xxx" 形式
+    // そのため全タスクから正規化後のbranch名で比較する
+    const tasks = await prisma.task.findMany({
+      where: { owner: parsed.owner, repo: parsed.repo, deletedAt: null },
+      include: { tabs: true },
+    });
+    return (
+      tasks.find((t) => {
+        const normalized = t.branch.replace(/\//g, '-');
+        return normalized === parsed.branch;
+      }) ?? null
+    );
+  }
+  return null;
+}
+
+/** タスク指定パラメータの共通inputSchema */
+const taskIdentifierProperties = {
+  id: { type: 'string' as const, description: 'タスクID' },
+  session_id: {
+    type: 'string' as const,
+    description: 'セッションID（環境変数 TSUNAGI_SESSION_ID の値）',
+  },
+  cwd: { type: 'string' as const, description: '作業ディレクトリパス' },
+};
 
 /** MCPサーバーインスタンスを作成して全toolsを登録する */
 function createMcpServer(): Server {
@@ -33,12 +98,12 @@ function createMcpServer(): Server {
       },
       {
         name: 'tsunagi_get_task',
-        description: 'タスク詳細を取得する（tabs含む）',
+        description:
+          'タスク詳細を取得する（tabs含む）。id, session_id, cwd のいずれかでタスクを指定する。',
         inputSchema: {
           type: 'object',
-          required: ['id'],
           properties: {
-            id: { type: 'string', description: 'タスクID' },
+            ...taskIdentifierProperties,
           },
         },
       },
@@ -64,12 +129,11 @@ function createMcpServer(): Server {
       },
       {
         name: 'tsunagi_update_task',
-        description: 'タスクを更新する（status/effort等）',
+        description: 'タスクを更新する。id, session_id, cwd のいずれかでタスクを指定する。',
         inputSchema: {
           type: 'object',
-          required: ['id'],
           properties: {
-            id: { type: 'string', description: 'タスクID' },
+            ...taskIdentifierProperties,
             title: { type: 'string', description: 'タスクタイトル' },
             description: { type: 'string', description: 'タスク詳細説明' },
             status: {
@@ -78,17 +142,19 @@ function createMcpServer(): Server {
               description: 'ステータス',
             },
             effort: { type: 'number', description: '工数（時間）' },
+            baseBranch: { type: 'string', description: 'ベースブランチ名' },
+            pullRequestUrl: { type: 'string', description: 'Pull Request URL' },
           },
         },
       },
       {
         name: 'tsunagi_delete_task',
-        description: 'タスクを削除する（soft delete）',
+        description:
+          'タスクを削除する（soft delete）。id, session_id, cwd のいずれかでタスクを指定する。',
         inputSchema: {
           type: 'object',
-          required: ['id'],
           properties: {
-            id: { type: 'string', description: 'タスクID' },
+            ...taskIdentifierProperties,
           },
         },
       },
@@ -141,14 +207,10 @@ function createMcpServer(): Server {
       }
 
       case 'tsunagi_get_task': {
-        const { id } = (args ?? {}) as { id: string };
-        const task = await prisma.task.findUnique({
-          where: { id },
-          include: { tabs: true },
-        });
+        const task = await resolveTask(args as { id?: string; session_id?: string; cwd?: string });
         if (!task) {
           return {
-            content: [{ type: 'text', text: `Task not found: ${id}` }],
+            content: [{ type: 'text', text: 'Task not found' }],
             isError: true,
           };
         }
@@ -198,29 +260,45 @@ function createMcpServer(): Server {
       }
 
       case 'tsunagi_update_task': {
-        const { id, title, description, status, effort } = (args ?? {}) as {
-          id: string;
+        const {
+          id,
+          session_id,
+          cwd,
+          title,
+          description,
+          status,
+          effort,
+          baseBranch,
+          pullRequestUrl,
+        } = (args ?? {}) as {
+          id?: string;
+          session_id?: string;
+          cwd?: string;
           title?: string;
           description?: string;
           status?: string;
           effort?: number;
+          baseBranch?: string;
+          pullRequestUrl?: string;
         };
 
-        const existing = await prisma.task.findUnique({ where: { id } });
+        const existing = await resolveTask({ id, session_id, cwd });
         if (!existing) {
           return {
-            content: [{ type: 'text', text: `Task not found: ${id}` }],
+            content: [{ type: 'text', text: 'Task not found' }],
             isError: true,
           };
         }
 
         const updated = await prisma.task.update({
-          where: { id },
+          where: { id: existing.id },
           data: {
             ...(title !== undefined ? { title } : {}),
             ...(description !== undefined ? { description } : {}),
             ...(status !== undefined ? { status } : {}),
             ...(effort !== undefined ? { effort } : {}),
+            ...(baseBranch !== undefined ? { baseBranch } : {}),
+            ...(pullRequestUrl !== undefined ? { pullRequestUrl } : {}),
           },
           include: { tabs: true },
         });
@@ -230,20 +308,19 @@ function createMcpServer(): Server {
       }
 
       case 'tsunagi_delete_task': {
-        const { id } = (args ?? {}) as { id: string };
-        const existing = await prisma.task.findUnique({ where: { id } });
-        if (!existing) {
+        const task = await resolveTask(args as { id?: string; session_id?: string; cwd?: string });
+        if (!task) {
           return {
-            content: [{ type: 'text', text: `Task not found: ${id}` }],
+            content: [{ type: 'text', text: 'Task not found' }],
             isError: true,
           };
         }
         await prisma.task.update({
-          where: { id },
+          where: { id: task.id },
           data: { deletedAt: new Date() },
         });
         return {
-          content: [{ type: 'text', text: `Task deleted: ${id}` }],
+          content: [{ type: 'text', text: `Task deleted: ${task.id}` }],
         };
       }
 

--- a/tsunagi-marketplace/.claude-plugin/marketplace.json
+++ b/tsunagi-marketplace/.claude-plugin/marketplace.json
@@ -1,0 +1,11 @@
+{
+  "name": "tsunagi-marketplace",
+  "owner": { "name": "minimalcorp" },
+  "plugins": [
+    {
+      "name": "tsunagi-plugin",
+      "source": "./plugins/tsunagi-plugin",
+      "description": "tsunagiサーバーへClaude CLIイベントを転送し、MCPサーバーとタスク管理スキルを提供する"
+    }
+  ]
+}

--- a/tsunagi-marketplace/plugins/tsunagi-plugin/.claude-plugin/plugin.json
+++ b/tsunagi-marketplace/plugins/tsunagi-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,233 @@
+{
+  "name": "tsunagi-plugin",
+  "version": "1.0.2",
+  "description": "tsunagiサーバーへClaude CLIイベントを転送し、MCPサーバーとタスク管理スキルを提供する",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -s -X POST http://localhost:2792/hooks/claude -H 'Content-Type: application/json' -d @-"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -s -X POST http://localhost:2792/hooks/claude -H 'Content-Type: application/json' -d @-"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -s -X POST http://localhost:2792/hooks/claude -H 'Content-Type: application/json' -d @-"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -s -X POST http://localhost:2792/hooks/claude -H 'Content-Type: application/json' -d @-"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -s -X POST http://localhost:2792/hooks/claude -H 'Content-Type: application/json' -d @-"
+          }
+        ]
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -s -X POST http://localhost:2792/hooks/claude -H 'Content-Type: application/json' -d @-"
+          }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -s -X POST http://localhost:2792/hooks/claude -H 'Content-Type: application/json' -d @-"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -s -X POST http://localhost:2792/hooks/claude -H 'Content-Type: application/json' -d @-"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -s -X POST http://localhost:2792/hooks/claude -H 'Content-Type: application/json' -d @-"
+          }
+        ]
+      }
+    ],
+    "StopFailure": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -s -X POST http://localhost:2792/hooks/claude -H 'Content-Type: application/json' -d @-"
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -s -X POST http://localhost:2792/hooks/claude -H 'Content-Type: application/json' -d @-"
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -s -X POST http://localhost:2792/hooks/claude -H 'Content-Type: application/json' -d @-"
+          }
+        ]
+      }
+    ],
+    "TeammateIdle": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -s -X POST http://localhost:2792/hooks/claude -H 'Content-Type: application/json' -d @-"
+          }
+        ]
+      }
+    ],
+    "TaskCompleted": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -s -X POST http://localhost:2792/hooks/claude -H 'Content-Type: application/json' -d @-"
+          }
+        ]
+      }
+    ],
+    "InstructionsLoaded": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -s -X POST http://localhost:2792/hooks/claude -H 'Content-Type: application/json' -d @-"
+          }
+        ]
+      }
+    ],
+    "ConfigChange": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -s -X POST http://localhost:2792/hooks/claude -H 'Content-Type: application/json' -d @-"
+          }
+        ]
+      }
+    ],
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -s -X POST http://localhost:2792/hooks/claude -H 'Content-Type: application/json' -d @-"
+          }
+        ]
+      }
+    ],
+    "WorktreeRemove": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -s -X POST http://localhost:2792/hooks/claude -H 'Content-Type: application/json' -d @-"
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -s -X POST http://localhost:2792/hooks/claude -H 'Content-Type: application/json' -d @-"
+          }
+        ]
+      }
+    ],
+    "PostCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -s -X POST http://localhost:2792/hooks/claude -H 'Content-Type: application/json' -d @-"
+          }
+        ]
+      }
+    ],
+    "Elicitation": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -s -X POST http://localhost:2792/hooks/claude -H 'Content-Type: application/json' -d @-"
+          }
+        ]
+      }
+    ],
+    "ElicitationResult": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "curl -s -X POST http://localhost:2792/hooks/claude -H 'Content-Type: application/json' -d @-"
+          }
+        ]
+      }
+    ]
+  },
+  "mcpServers": {
+    "tsunagi": {
+      "type": "sse",
+      "url": "http://localhost:2792/mcp"
+    }
+  }
+}

--- a/tsunagi-marketplace/plugins/tsunagi-plugin/skills/tsunagi-task/SKILL.md
+++ b/tsunagi-marketplace/plugins/tsunagi-plugin/skills/tsunagi-task/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: tsunagi-task
+description: tsunagiタスク管理。タスクのCRUD操作や、現在のタスクの特定に使用する。
+---
+
+## 現在のタスクを特定する
+
+タスク操作には `id`, `session_id`, `cwd` のいずれかでタスクを指定する。
+優先順位: id > session_id > cwd
+
+### 推奨: session_id を使う
+
+環境変数 `TSUNAGI_SESSION_ID` が設定されている場合、これを `session_id` パラメータとして渡す。
+tsunagiのタブから起動されたClaudeセッションでは常にこの環境変数が利用可能。
+
+### フォールバック: cwd を使う
+
+`TSUNAGI_SESSION_ID` が未設定の場合（worktreeで直接claude起動時）、CWDを `cwd` パラメータとして渡す。
+
+## タスク操作
+
+| 操作     | ツール              | タスク指定              | その他パラメータ                                                     |
+| -------- | ------------------- | ----------------------- | -------------------------------------------------------------------- |
+| 一覧取得 | tsunagi_list_tasks  | 不要                    | owner?, repo?, status?                                               |
+| 詳細取得 | tsunagi_get_task    | id or session_id or cwd | -                                                                    |
+| 作成     | tsunagi_create_task | 不要                    | owner, repo, title, description?, effort?, status?                   |
+| 更新     | tsunagi_update_task | id or session_id or cwd | title?, description?, status?, effort?, baseBranch?, pullRequestUrl? |
+| 削除     | tsunagi_delete_task | id or session_id or cwd | -                                                                    |
+
+## ステータス遷移
+
+backlog → planning → coding → reviewing → done
+
+## 注意事項
+
+- `id`, `session_id`, `cwd` は優先順位に従い最初にマッチしたものでタスクを解決する
+- 削除は論理削除（復元不可）
+- `tsunagi_create_task` が失敗した場合、エラー内容をユーザーに報告するだけでよい（原因の深掘り不要）


### PR DESCRIPTION
- tsunagi-marketplace + tsunagi-plugin のディレクトリ構造を作成
- plugin.jsonにhooks(全22イベント)、MCPサーバー、skillsをinline定義
- MCPツールにid/session_id/cwdの3方式でタスク解決するresolveTaskヘルパーを追加
- tsunagi_update_taskにbaseBranch, pullRequestUrlフィールドを追加
- サーバー起動ラッパー(scripts/with-plugin.ts)でpluginのinstall/uninstallライフサイクルを管理
- package.jsonのdev/startスクリプトをラッパー経由に変更