### PR TITLE
fix: Monaco Editorのポーリングタイムアウトを撤廃し編集中テキスト消失を防止

### DIFF
--- a/scripts/monaco-editor.sh
+++ b/scripts/monaco-editor.sh
@@ -32,17 +32,12 @@ fi
 
 echo "Opening Monaco Editor in browser... (session: $SESSION_ID)" >&2
 
-# 完了までポーリング（最大10分、1秒間隔）
+# 完了までポーリング（無制限、1秒間隔。Ctrl+C で中断可能）
 # レスポンスはプレーンテキスト "done" or "pending"（JSON パース不要）
-i=0
-while [ $i -lt 600 ]; do
+while true; do
   STATUS=$(curl -sf "$API_BASE/api/editor/session/$SESSION_ID" 2>/dev/null || echo "pending")
   if [ "$STATUS" = "done" ]; then
     exit 0
   fi
   sleep 1
-  i=$((i + 1))
 done
-
-echo "Error: Timed out waiting for editor (10 min)" >&2
-exit 1

--- a/server/editor-session-store.ts
+++ b/server/editor-session-store.ts
@@ -7,11 +7,11 @@ interface EditorSession {
 
 export const editorSessionStore = new Map<string, EditorSession>();
 
-// 10分以上経過したセッションを定期クリーンアップ
+// 完了済みセッションを10分後にクリーンアップ（編集中のセッションは保持）
 setInterval(() => {
   const threshold = Date.now() - 10 * 60 * 1000;
   for (const [id, session] of editorSessionStore) {
-    if (session.createdAt < threshold) {
+    if (session.status === 'done' && session.createdAt < threshold) {
       editorSessionStore.delete(id);
     }
   }


### PR DESCRIPTION
ポーリングを無制限ループに変更し、セッションクリーンアップを完了済みのみに限定