### PR TITLE
fix: MCPルートでorder/effortをNumber()で型変換してからサービス層に渡す

### DIFF
--- a/server/routes/mcp.ts
+++ b/server/routes/mcp.ts
@@ -213,8 +213,8 @@ function createMcpServer(io?: SocketIOServer): Server {
               repo,
               title,
               description,
-              effort,
-              order,
+              effort: effort !== undefined ? Number(effort) : undefined,
+              order: order !== undefined ? Number(order) : undefined,
               status: status as import('../../src/lib/types.js').Task['status'] | undefined,
               branch,
               baseBranch,
@@ -256,8 +256,8 @@ function createMcpServer(io?: SocketIOServer): Server {
               ...(status !== undefined
                 ? { status: status as import('../../src/lib/types.js').Task['status'] }
                 : {}),
-              ...(effort !== undefined ? { effort } : {}),
-              ...(order !== undefined ? { order } : {}),
+              ...(effort !== undefined ? { effort: Number(effort) } : {}),
+              ...(order !== undefined ? { order: Number(order) } : {}),
               ...(baseBranch !== undefined ? { baseBranch } : {}),
               ...(pullRequestUrl !== undefined ? { pullRequestUrl } : {}),
             },


### PR DESCRIPTION
MCP経由で受け取ったorder/effortパラメータが文字列のままPrismaに渡され
PrismaClientValidationError (Expected Int, provided String) が発生していた