### PR TITLE
fix: MonacoEditorModalでEscキーによるダイアログ閉じを無効化

### DIFF
--- a/src/components/MonacoEditorModal.tsx
+++ b/src/components/MonacoEditorModal.tsx
@@ -91,6 +91,7 @@ export function MonacoEditorModal({
       showCloseButton={true}
       trapFocus={false}
       restoreFocus={false}
+      dismissOnEsc={false}
     >
       <div className="space-y-4">
         <div
@@ -123,11 +124,6 @@ export function MonacoEditorModal({
                   e.stopPropagation();
                   handleSubmitRef.current();
                 }
-                if (e.keyCode === monacoInstance.KeyCode.Escape) {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  handleCancelRef.current();
-                }
               });
             }}
             options={{
@@ -141,7 +137,7 @@ export function MonacoEditorModal({
           />
         </div>
         <p className="text-xs text-muted-foreground">
-          {isMac ? 'Cmd+Enter' : 'Ctrl+Enter'} で{submitLabel}、Esc でキャンセル
+          {isMac ? 'Cmd+Enter' : 'Ctrl+Enter'} で{submitLabel}
         </p>
         <div className="flex justify-end gap-2">
           <Button variant="outline" size="lg" onClick={handleCancel}>

--- a/src/components/ui/Dialog.tsx
+++ b/src/components/ui/Dialog.tsx
@@ -24,6 +24,8 @@ interface DialogProps {
   trapFocus?: boolean;
   /** ダイアログを閉じた時にフォーカスを元の要素に戻すか（デフォルト: true） */
   restoreFocus?: boolean;
+  /** Escキーでダイアログを閉じるか（デフォルト: true） */
+  dismissOnEsc?: boolean;
 }
 
 const maxWidthClasses = {
@@ -44,6 +46,7 @@ export function Dialog({
   maxWidth = '2xl',
   showCloseButton = true,
   initialFocusEl,
+  dismissOnEsc = true,
 }: DialogProps) {
   // Handle initialFocusEl by focusing the element after dialog opens
   useEffect(() => {
@@ -58,7 +61,8 @@ export function Dialog({
     }
   }, [open, initialFocusEl]);
 
-  const handleOpenChange = (openState: boolean) => {
+  const handleOpenChange = (openState: boolean, eventDetails: { reason?: string }) => {
+    if (!openState && !dismissOnEsc && eventDetails.reason === 'escape-key') return;
     onOpenChange({ open: openState });
   };
 


### PR DESCRIPTION
DialogにdismissOnEsc propを追加し、MonacoEditorModalではEscキーで ダイアログが閉じないよう制御。suggest widget等のEsc操作が安全に動作する。