### PR TITLE
fix: editor:openイベントをアクティブソケットのみに送信しブラウザタブ間の隔離を実現

### DIFF
--- a/server/pty-manager.ts
+++ b/server/pty-manager.ts
@@ -21,6 +21,22 @@ export interface PtySession {
 
 class PtyManager {
   private sessions = new Map<string, PtySession>();
+  /** sessionId → 最後に input を送信した socket.id */
+  private activeSocketIds = new Map<string, string>();
+
+  setActiveSocket(sessionId: string, socketId: string): void {
+    this.activeSocketIds.set(sessionId, socketId);
+  }
+
+  getActiveSocket(sessionId: string): string | undefined {
+    return this.activeSocketIds.get(sessionId);
+  }
+
+  clearActiveSocket(sessionId: string, socketId: string): void {
+    if (this.activeSocketIds.get(sessionId) === socketId) {
+      this.activeSocketIds.delete(sessionId);
+    }
+  }
 
   createSession(sessionId: string, cwd: string, env?: Record<string, string>): PtySession {
     if (this.sessions.has(sessionId)) {

--- a/server/routes/editor.ts
+++ b/server/routes/editor.ts
@@ -3,6 +3,7 @@ import type { FastifyInstance } from 'fastify';
 import type { Server as SocketIOServer } from 'socket.io';
 import { randomUUID } from 'crypto';
 import { editorSessionStore } from '../editor-session-store.js';
+import { ptyManager } from '../pty-manager.js';
 
 interface FastifyWithIO extends FastifyInstance {
   io: SocketIOServer;
@@ -35,9 +36,15 @@ export async function editorRoutes(fastify: FastifyInstance) {
         createdAt: Date.now(),
       });
 
-      // tabIdが指定されていればそのタブのルームにのみ送信、なければ全体ブロードキャスト（後方互換）
+      // tabIdが指定されていれば、最後にinputを送信したソケットにのみ送信
+      // （同じtabルームに複数ブラウザタブのソケットが参加している場合の隔離）
       if (tabId) {
-        f.io.to(`tab:${tabId}`).emit('editor:open', { sessionId, content });
+        const activeSocketId = ptyManager.getActiveSocket(tabId);
+        if (activeSocketId) {
+          f.io.to(activeSocketId).emit('editor:open', { sessionId, content });
+        } else {
+          f.io.to(`tab:${tabId}`).emit('editor:open', { sessionId, content });
+        }
       } else {
         f.io.emit('editor:open', { sessionId, content });
       }

--- a/server/routes/terminal.ts
+++ b/server/routes/terminal.ts
@@ -113,9 +113,10 @@ export async function terminalRoutes(fastify: FastifyInstance) {
         }
       );
 
-      // input イベント: PTYへ書き込み
+      // input イベント: PTYへ書き込み + アクティブソケット追跡
       socket.on('input', ({ sessionId: sid, data }: { sessionId: string; data: string }) => {
         if (sid !== sessionId) return;
+        ptyManager.setActiveSocket(sessionId, socket.id);
         ptyProcess.write(data);
       });
     });
@@ -125,11 +126,12 @@ export async function terminalRoutes(fastify: FastifyInstance) {
       socket.emit('health-check-ack');
     });
 
-    // disconnect → ハンドラ解除・GCタイマーセット
+    // disconnect → ハンドラ解除・アクティブソケットクリア・GCタイマーセット
     socket.on('disconnect', () => {
       dataHandlerDispose?.();
       exitHandlerDispose?.();
       if (boundSessionId) {
+        ptyManager.clearActiveSocket(boundSessionId, socket.id);
         ptyManager.scheduleGc(boundSessionId);
       }
     });


### PR DESCRIPTION
Ctrl+Gで開くPrompt Editorが、同じページを開いている他のブラウザタブでも
表示されてしまう問題を修正。最後にinputを送信したソケットIDを追跡し、
editor:openをそのソケットのみに送信することで、操作中のブラウザタブだけに
モーダルが開くようにした。