### PR TITLE
feat: 設定画面のRepo選択時にリポジトリ削除機能を追加

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -7,6 +7,7 @@ import { EnvTreeNavigation, type SelectedNode } from '@/components/env/EnvTreeNa
 import { EnvVariableEditor } from '@/components/env/EnvVariableEditor';
 import { ClaudeTokenSection } from '@/components/env/ClaudeTokenSection';
 import { RepositoryManagement } from '@/components/settings/RepositoryManagement';
+import { RemoveRepositorySection } from '@/components/settings/RemoveRepositorySection';
 import { Button } from '@/components/ui/button';
 
 export default function SettingsPage() {
@@ -31,6 +32,7 @@ export default function SettingsPage() {
   };
 
   const [selectedNode, setSelectedNode] = useState<SelectedNode | null>(null);
+  const [treeRefreshKey, setTreeRefreshKey] = useState(0);
   const [onboardingStatus, setOnboardingStatus] = useState({
     completed: true,
     hasGlobalToken: true,
@@ -71,6 +73,11 @@ export default function SettingsPage() {
     setSelectedNode({ scope: 'global', label: 'Global' });
   };
 
+  const handleRepoDeleted = () => {
+    setSelectedNode({ scope: 'global', label: 'Global' });
+    setTreeRefreshKey((prev) => prev + 1);
+  };
+
   return (
     <div className="h-screen flex flex-col bg-background">
       {/* Header */}
@@ -95,7 +102,11 @@ export default function SettingsPage() {
       <div className="flex-1 flex min-h-0">
         {/* Left Panel: Tree Navigation */}
         <div className="w-64 border-r border-border bg-card">
-          <EnvTreeNavigation selectedNode={selectedNode} onNodeSelect={handleNodeSelect} />
+          <EnvTreeNavigation
+            selectedNode={selectedNode}
+            onNodeSelect={handleNodeSelect}
+            refreshKey={treeRefreshKey}
+          />
         </div>
 
         {/* Right Panel: Editor */}
@@ -118,6 +129,15 @@ export default function SettingsPage() {
                   <h2 className="text-sm font-semibold text-foreground">Repositories</h2>
                   <RepositoryManagement />
                 </div>
+              )}
+
+              {/* Remove Repository (Repo scope only) */}
+              {selectedNode.scope === 'repo' && selectedNode.owner && selectedNode.repo && (
+                <RemoveRepositorySection
+                  owner={selectedNode.owner}
+                  repo={selectedNode.repo}
+                  onDeleted={handleRepoDeleted}
+                />
               )}
             </div>
           ) : (

--- a/src/components/env/EnvTreeNavigation.tsx
+++ b/src/components/env/EnvTreeNavigation.tsx
@@ -13,6 +13,7 @@ export interface SelectedNode {
 interface EnvTreeNavigationProps {
   selectedNode: SelectedNode | null;
   onNodeSelect: (node: SelectedNode) => void;
+  refreshKey?: number;
 }
 
 interface Owner {
@@ -20,7 +21,11 @@ interface Owner {
   repositories: Array<{ owner: string; repo: string }>;
 }
 
-export function EnvTreeNavigation({ selectedNode, onNodeSelect }: EnvTreeNavigationProps) {
+export function EnvTreeNavigation({
+  selectedNode,
+  onNodeSelect,
+  refreshKey,
+}: EnvTreeNavigationProps) {
   const [treeData, setTreeData] = useState<TreeNode[]>([]);
   const [expandedOwners, setExpandedOwners] = useState<Set<string>>(new Set());
   const [isLoading, setIsLoading] = useState(true);
@@ -87,7 +92,7 @@ export function EnvTreeNavigation({ selectedNode, onNodeSelect }: EnvTreeNavigat
     };
 
     loadTree();
-  }, []);
+  }, [refreshKey]);
 
   const handleToggle = (nodeId: string) => {
     setExpandedOwners((prev) => {

--- a/src/components/settings/RemoveRepositorySection.tsx
+++ b/src/components/settings/RemoveRepositorySection.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { useState } from 'react';
+import { Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog-primitives';
+
+interface RemoveRepositorySectionProps {
+  owner: string;
+  repo: string;
+  onDeleted: () => void;
+}
+
+export function RemoveRepositorySection({ owner, repo, onDeleted }: RemoveRepositorySectionProps) {
+  const [open, setOpen] = useState(false);
+  const [confirmInput, setConfirmInput] = useState('');
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const repoFullName = `${owner}/${repo}`;
+  const isConfirmed = confirmInput === repoFullName;
+
+  const handleDelete = async () => {
+    if (!isConfirmed) return;
+
+    setIsDeleting(true);
+    try {
+      const res = await fetch(`/api/repos/${owner}/${repo}`, { method: 'DELETE' });
+      if (!res.ok) throw new Error('Failed to delete repository');
+      onDeleted();
+    } catch (error) {
+      console.error('Failed to delete repository:', error);
+    } finally {
+      setIsDeleting(false);
+      setOpen(false);
+      setConfirmInput('');
+    }
+  };
+
+  return (
+    <>
+      <div className="rounded-md border border-destructive/30 p-4 space-y-3">
+        <div className="space-y-1">
+          <h3 className="text-sm font-semibold text-destructive">Remove Repository</h3>
+          <p className="text-xs text-muted-foreground">
+            Remove this repository and all associated data including tasks, worktrees, and
+            environment variables. This action cannot be undone.
+          </p>
+        </div>
+        <Button variant="destructive" size="sm" onClick={() => setOpen(true)}>
+          <Trash2 className="size-4" />
+          Remove Repository
+        </Button>
+      </div>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent showCloseButton={false}>
+          <DialogHeader>
+            <DialogTitle>Remove Repository</DialogTitle>
+            <DialogDescription>
+              This will permanently delete <strong>{repoFullName}</strong> and all associated tasks,
+              worktrees, and environment variables.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-2">
+            <label className="text-xs text-muted-foreground">
+              Type <strong>{repoFullName}</strong> to confirm
+            </label>
+            <Input
+              value={confirmInput}
+              onChange={(e) => setConfirmInput(e.target.value)}
+              placeholder={repoFullName}
+              autoComplete="off"
+            />
+          </div>
+
+          <DialogFooter>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                setOpen(false);
+                setConfirmInput('');
+              }}
+              disabled={isDeleting}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={handleDelete}
+              disabled={!isConfirmed || isDeleting}
+            >
+              {isDeleting ? 'Removing...' : 'Remove'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}


### PR DESCRIPTION
Repoスコープ選択時の右パネル下部に「Remove Repository」セクションを配置し、
リポジトリ名入力による確認ダイアログ付きで安全に削除できるようにした。