### PR TITLE
fix: 空リポジトリのcloneがset-head失敗で500になる問題を修正

### DIFF
--- a/src/app/api/clone/route.ts
+++ b/src/app/api/clone/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { createRepo } from '@/lib/repositories/repository';
 import { initBareRepository, authenticateGhCli } from '@/lib/worktree-manager';
 import { getEnv } from '@/lib/repositories/environment';
+import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
 
@@ -63,7 +64,17 @@ export async function POST(request: Request) {
     const bareRepoPath = path.join(os.homedir(), '.tsunagi', 'workspaces', owner, repo, '.bare');
 
     // Bare cloneを実行
-    await initBareRepository(owner, repo, gitUrl);
+    try {
+      await initBareRepository(owner, repo, gitUrl);
+    } catch (error) {
+      // clone失敗時は中途半端に作成された bare ディレクトリを削除してから再スロー
+      try {
+        await fs.rm(bareRepoPath, { recursive: true, force: true });
+      } catch (cleanupError) {
+        console.warn('Failed to cleanup bare repository after clone failure:', cleanupError);
+      }
+      throw error;
+    }
 
     // Repository登録
     const newRepo = await createRepo({

--- a/src/lib/worktree-manager.ts
+++ b/src/lib/worktree-manager.ts
@@ -81,7 +81,13 @@ export async function initBareRepository(
   await bareGit.fetch();
 
   // origin/HEADを設定
-  await bareGit.raw(['remote', 'set-head', 'origin', '--auto']);
+  // 空リポジトリ（リモートにブランチが1つもない）の場合は set-head が失敗するが、
+  // clone自体は成功させる。getDefaultBranch() 側の fallback で対応される。
+  try {
+    await bareGit.raw(['remote', 'set-head', 'origin', '--auto']);
+  } catch (error) {
+    console.warn('Failed to set origin/HEAD (empty repository?):', error);
+  }
 
   return bareRepoPath;
 }
@@ -105,7 +111,12 @@ export async function fetchRemote(owner: string, repo: string): Promise<void> {
   // Git configに設定されたfetch refspecを使用
   await git.fetch('origin', { '--prune': null });
   // origin/HEADをリモートの最新デフォルトブランチに自動更新
-  await git.remote(['set-head', 'origin', '--auto']);
+  // 空リポジトリの場合は失敗するが、fetch自体は成功しているので無視する
+  try {
+    await git.remote(['set-head', 'origin', '--auto']);
+  } catch (error) {
+    console.warn('Failed to set origin/HEAD (empty repository?):', error);
+  }
 }
 
 // リモートブランチの一覧を取得


### PR DESCRIPTION
- initBareRepository/fetchRemote の `git remote set-head origin --auto` を try/catch で囲み、リモートにブランチがない空リポジトリでも clone を成功させる
- /api/clone で clone 失敗時に作成途中の bare ディレクトリを削除し、再cloneの手動リカバリを不要にする