### PR TITLE
feat: ホスト用 .mcp.json に GitHub MCP サーバーを追加

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -19,6 +19,20 @@
         "--transport",
         "stdio"
       ]
+    },
+    "github": {
+      "command": "docker",
+      "args": [
+        "run",
+        "--rm",
+        "-i",
+        "-e",
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "ghcr.io/github/github-mcp-server"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PAT}"
+      }
     }
   }
 }


### PR DESCRIPTION
Docker経由で ghcr.io/github/github-mcp-server を起動し、
GITHUB_PAT を GITHUB_PERSONAL_ACCESS_TOKEN として渡す。