### PR TITLE
feat: SQLite DB バックアップ / 復元スクリプトを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,24 @@ shadcn/ui preset `b2W68tmsa` 準拠。
 
 - `h-9 rounded-md border border-input bg-transparent shadow-xs`
 
+## データベースマイグレーション前の必須手順
+
+`prisma migrate`, `prisma db push`, `prisma migrate reset` 等のDB変更コマンドを実行する前に、**必ず** `npm run db:backup` を先に実行すること。
+
+これは複数Claudeプロセスが単一DBを共有する開発環境で、マイグレーション失敗時の復旧手段を確保するため。
+
+バックアップは `~/.tsunagi/backups/yyyyMMddHHmmss.db` として保存され、直近5件が保持される。
+
+### 復元手順
+
+migrationやデータ破壊が発生した場合、最新バックアップから復元できる:
+
+1. tsunagi サーバーを停止（Ctrl+C）
+2. `npm run db:restore` を実行
+3. `npm run dev` で再起動
+
+`db:restore` は最新のバックアップを自動選択し、現在のDBを `tsunagi.db.broken-<timestamp>` に退避した上で復元する。
+
 ## Git操作のルール
 
 - **作業完了後に勝手にcommitしない**

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "db:migrate": "npx prisma migrate dev",
     "db:generate": "npx prisma generate",
     "db:studio": "npx prisma studio",
-    "db:migrate-from-json": "tsx scripts/migrate-to-sqlite.ts"
+    "db:migrate-from-json": "tsx scripts/migrate-to-sqlite.ts",
+    "db:backup": "tsx scripts/db-backup.ts",
+    "db:restore": "tsx scripts/db-restore.ts"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",

--- a/scripts/db-backup.ts
+++ b/scripts/db-backup.ts
@@ -1,0 +1,71 @@
+import { createClient } from '@libsql/client';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const RETENTION_COUNT = 5;
+
+function getTsunagiDataDir(): string {
+  return process.env.TSUNAGI_DATA_DIR || path.join(process.env.HOME || '~', '.tsunagi');
+}
+
+function getDatabasePath(): string {
+  return path.join(getTsunagiDataDir(), 'state', 'tsunagi.db');
+}
+
+function getBackupDir(): string {
+  return path.join(getTsunagiDataDir(), 'backups');
+}
+
+function formatTimestamp(date: Date): string {
+  const pad = (n: number) => n.toString().padStart(2, '0');
+  return (
+    `${date.getFullYear()}` +
+    pad(date.getMonth() + 1) +
+    pad(date.getDate()) +
+    pad(date.getHours()) +
+    pad(date.getMinutes()) +
+    pad(date.getSeconds())
+  );
+}
+
+async function backup() {
+  const dbPath = getDatabasePath();
+  const backupDir = getBackupDir();
+
+  if (!fs.existsSync(dbPath)) {
+    console.error(`Error: database not found at ${dbPath}`);
+    process.exit(1);
+  }
+
+  fs.mkdirSync(backupDir, { recursive: true });
+
+  const ts = formatTimestamp(new Date());
+  const backupPath = path.join(backupDir, `${ts}.db`);
+
+  const client = createClient({ url: `file:${dbPath}` });
+  try {
+    await client.execute(`VACUUM INTO '${backupPath.replace(/'/g, "''")}'`);
+  } finally {
+    client.close();
+  }
+
+  console.log(`Backup created: ${backupPath}`);
+
+  // Retention: keep only the newest RETENTION_COUNT backups
+  const files = fs
+    .readdirSync(backupDir)
+    .filter((f) => /^\d{14}\.db$/.test(f))
+    .sort();
+
+  while (files.length > RETENTION_COUNT) {
+    const oldest = files.shift();
+    if (!oldest) break;
+    fs.unlinkSync(path.join(backupDir, oldest));
+    console.log(`Removed old backup: ${oldest}`);
+  }
+}
+
+backup().catch((err) => {
+  console.error('Backup failed:', err);
+  process.exit(1);
+});

--- a/scripts/db-restore.ts
+++ b/scripts/db-restore.ts
@@ -1,0 +1,94 @@
+import { execSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+function getTsunagiDataDir(): string {
+  return process.env.TSUNAGI_DATA_DIR || path.join(process.env.HOME || '~', '.tsunagi');
+}
+
+function getDatabasePath(): string {
+  return path.join(getTsunagiDataDir(), 'state', 'tsunagi.db');
+}
+
+function getBackupDir(): string {
+  return path.join(getTsunagiDataDir(), 'backups');
+}
+
+function formatTimestamp(date: Date): string {
+  const pad = (n: number) => n.toString().padStart(2, '0');
+  return (
+    `${date.getFullYear()}` +
+    pad(date.getMonth() + 1) +
+    pad(date.getDate()) +
+    pad(date.getHours()) +
+    pad(date.getMinutes()) +
+    pad(date.getSeconds())
+  );
+}
+
+function isDatabaseInUse(dbPath: string): boolean {
+  // macOS / Linux: use lsof to detect any process holding the DB file.
+  try {
+    const out = execSync(`lsof -- ${JSON.stringify(dbPath)} 2>/dev/null`, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return out.trim().length > 0;
+  } catch {
+    // lsof exits with non-zero when no process holds the file, or when lsof is unavailable.
+    return false;
+  }
+}
+
+function restore() {
+  const dbPath = getDatabasePath();
+  const backupDir = getBackupDir();
+
+  if (isDatabaseInUse(dbPath)) {
+    console.error(
+      'Error: tsunagi is still running (a process is holding the database).\n' +
+        'Stop the dev server first (Ctrl+C), then rerun this command.'
+    );
+    process.exit(1);
+  }
+
+  if (!fs.existsSync(backupDir)) {
+    console.error(`Error: backup directory not found: ${backupDir}`);
+    process.exit(1);
+  }
+
+  const backups = fs
+    .readdirSync(backupDir)
+    .filter((f) => /^\d{14}\.db$/.test(f))
+    .sort();
+
+  const latest = backups[backups.length - 1];
+  if (!latest) {
+    console.error(`Error: no backups found in ${backupDir}`);
+    process.exit(1);
+  }
+
+  // Move current DB files (.db, .db-wal, .db-shm) to .broken-<timestamp>
+  const ts = formatTimestamp(new Date());
+  for (const suffix of ['', '-wal', '-shm']) {
+    const src = `${dbPath}${suffix}`;
+    if (fs.existsSync(src)) {
+      const dest = `${src}.broken-${ts}`;
+      fs.renameSync(src, dest);
+      console.log(`Saved old file: ${dest}`);
+    }
+  }
+
+  const srcBackup = path.join(backupDir, latest);
+  fs.copyFileSync(srcBackup, dbPath);
+
+  console.log(`\nRestored from ${latest}`);
+  console.log('Now restart tsunagi with: npm run dev');
+}
+
+try {
+  restore();
+} catch (err) {
+  console.error('Restore failed:', err);
+  process.exit(1);
+}


### PR DESCRIPTION
複数Claudeプロセスが単一DBを共有する開発環境で、migration失敗時の
復旧手段を確保するため、VACUUM INTO ベースのバックアップと lsof
による起動中検出付きの復元スクリプトを追加。CLAUDE.md に migrate
前の必須手順を追記。