### PR TITLE
fix: Ctrl+G Monaco Editor Submit 後の claude 描画ズレを修正

### DIFF
--- a/scripts/monaco-editor.sh
+++ b/scripts/monaco-editor.sh
@@ -18,6 +18,22 @@ if [ -z "$TMPFILE" ]; then
   exit 1
 fi
 
+# 代替画面 (alt screen) に切り替えて script の出力を claude の描画領域から隔離する。
+# vim/nano 等の通常の $EDITOR と同じ作法。これをやらないと script の stderr 出力が
+# main buffer に積まれて、claude の Ink renderer の位置情報と実画面がズレ、
+# $EDITOR 終了後の描画に余白が生じる。
+printf '\033[?1049h'
+# どんな経路で終了しても alt screen から確実に復帰させる
+trap 'printf "\033[?1049l"' EXIT
+
+# エラー報告用: alt screen から抜けてから stderr に出す
+_error_exit() {
+  printf '\033[?1049l'
+  trap - EXIT
+  echo "Error: $1" >&2
+  exit 1
+}
+
 # ファイルパスを送信。サーバー側がファイルの読み書きを行う。
 # TSUNAGI_SESSION_ID はPTY作成時に設定される環境変数（= tab_id）
 # レスポンスはプレーンテキストの sessionId のみ（JSON パース不要）
@@ -26,18 +42,18 @@ SESSION_ID=$(curl -sf -X POST "$API_BASE/api/editor/session" \
   -d "{\"filePath\": \"$TMPFILE\", \"tabId\": \"$TSUNAGI_SESSION_ID\"}")
 
 if [ -z "$SESSION_ID" ]; then
-  echo "Error: Failed to create editor session (is tsunagi running? check monaco-editor.sh setup)" >&2
-  exit 1
+  _error_exit "Failed to create editor session (is tsunagi running? check monaco-editor.sh setup)"
 fi
 
-echo "Opening Monaco Editor in browser... (session: $SESSION_ID)" >&2
-
-# 完了までポーリング（無制限、1秒間隔。Ctrl+C で中断可能）
+# 完了までポーリング（無制限、0.1秒間隔。Ctrl+C で中断可能）
+# 速めの polling 間隔にしているのは、Cmd+Enter Submit 後に sh が foreground PG から
+# 抜けるまでの遅延を最小化するため（TerminalView 側の resize nudge が claude に
+# 届くように）。
 # レスポンスはプレーンテキスト "done" or "pending"（JSON パース不要）
 while true; do
   STATUS=$(curl -sf "$API_BASE/api/editor/session/$SESSION_ID" 2>/dev/null || echo "pending")
   if [ "$STATUS" = "done" ]; then
     exit 0
   fi
-  sleep 1
+  sleep 0.1
 done

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -244,12 +244,35 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
     }
     function handleEditorSessionDone() {
       isExternalEditorOpenRef.current = false;
-      // Ctrl+L で Claude Code に再描画させる
-      const socket = socketRef.current;
-      const sid = sessionIdRef.current;
-      if (socket?.connected && sid) {
-        socket.emit('input', { sessionId: sid, data: '\x0c' });
-      }
+      // claude 2.1.94 は $EDITOR 終了後に Ink の内部状態と実画面の position がズレて
+      // 余白が発生する。実ブラウザリサイズでは直ることを確認済みなので、
+      // プログラム側から疑似的な dimension 変化 (bump-then-restore) を注入して
+      // Node.js の 'resize' event → Ink の full re-layout を強制発火させる。
+      //
+      // 注意点:
+      // - Node.js の 'resize' event は process.stdout の cols/rows が実際に
+      //   変化した時のみ発火するため、同サイズ resize では効かない。
+      // - 200ms 遅延: monaco-editor.sh が polling から exit して foreground PG が
+      //   claude に戻るのを待つ。sh が前景にいる間に resize すると SIGWINCH が
+      //   sh に届いてしまう。
+      // - rows+1: 一瞬増やす方向にすることで、入力欄が画面外に押し出される
+      //   flicker を避ける (rows-1 だと入力欄が 1 行上に動くのが見える)。
+      // - 30ms の間隔: 2 回の resize を別 tick で処理させて、Node 側で集約され
+      //   てしまうのを防ぐ。
+      setTimeout(() => {
+        const socket = socketRef.current;
+        const sid = sessionIdRef.current;
+        const term = termRef.current;
+        if (!socket?.connected || !sid || !term) return;
+        socket.emit('resize', { sessionId: sid, cols: term.cols, rows: term.rows + 1 });
+        setTimeout(() => {
+          const t = termRef.current;
+          const s = socketRef.current;
+          if (s?.connected && sid && t) {
+            s.emit('resize', { sessionId: sid, cols: t.cols, rows: t.rows });
+          }
+        }, 30);
+      }, 200);
       // アクティブタブのみフォーカスを復帰する
       if (!isActiveRef.current) return;
       // xterm 内の textarea を直接 focus する（Terminal.focus() では効かない）


### PR DESCRIPTION
claude 2.1.94 で Ctrl+G → Monaco Editor → Cmd+Enter Submit 後に、 編集内容が claude に反映されず、ターミナル表示に余白が発生する問題を修正。

## 原因

1. monaco-editor.sh が alt screen を使わずに stderr へ echo していたため、 vim/nano 等の通常の \$EDITOR と異なり、script の出力が main buffer に 積まれて claude の Ink renderer の位置情報と実画面がズレていた。 (claude 2.1.92 までは TerminalView から送る Ctrl+L によるフル再描画で ズレを誤魔化せていたが、2.1.94 で Ctrl+L の扱いが変わり露呈した)

2. claude 2.1.94 は \$EDITOR 終了後に prompt 部分のみ差分更新し、 message 領域の position 再計算を行わない。ブラウザ手動リサイズで 直ることから、Node.js 'resize' event 経由の Ink full re-layout は 健全に動作している。

## 修正

- scripts/monaco-editor.sh: 冒頭で alt screen に切り替え、trap EXIT で 確実に復帰させる。vim 等と同じ \$EDITOR 作法に揃える。 polling 間隔を 1s → 0.1s に短縮し、sh exit 後の claude foreground 復帰 までの遅延を最小化。

- src/components/TerminalView.tsx handleEditorSessionDone: Ctrl+L (\x0c) emit を削除し、代わりに 200ms 遅延 (sh exit 待ち) の後に PTY を (cols, rows+1) → (cols, rows) で bump-then-restore resize。 Node.js の 'resize' event は dimensions 実変化時のみ発火するため、 実際にサイズを一瞬変化させる必要がある。rows+1 方向を選ぶのは、 rows-1 だと入力欄が画面内で上にズレて flicker が見えるため。 30ms 間隔は、2 回の resize が同一 tick で集約されるのを防ぐため。