### PR TITLE
fix(release): main protected branch への push を Deploy Key 経由にする

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,11 +56,21 @@ jobs:
       # npm Trusted Publishing (OIDC) と provenance 自動生成のため必須。
       id-token: write
     steps:
+      # main 保護 ruleset を bypass するため、Deploy Key を使って checkout
+      # する。actions/checkout は `ssh-key` が指定されると ephemeral な SSH
+      # agent を起動して private key をロードし、git remote URL を SSH
+      # (git@github.com:owner/repo.git) に設定する。以降の `git push` は
+      # この deploy key で認証されて protected main に push できる。
+      #
+      # 事前準備 (詳細は RELEASE_SETUP.md §2-3 参照):
+      #   1. SSH key pair を生成し public key を Deploy keys に登録 (write access)
+      #   2. private key を RELEASE_DEPLOY_KEY secret に登録
+      #   3. main ruleset の Bypass list にこの Deploy key を追加
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
release workflow は `npm version` bump commit と annotated tag を main に 直接 push する設計だが、main に branch protection ruleset を設定すると default の `GITHUB_TOKEN` (actor: github-actions[bot]) では bypass できず `protected branch hook declined` で fail する。

GitHub は github-actions[bot] を Ruleset Bypass list に直接追加する方法を 提供していない (セキュリティ上の意図的な制限)。そのため、repo-scoped な
Deploy Key を発行してその key を Bypass list に追加する方式を採用する。

workflow 側では `actions/checkout@v4` の `token:` を `ssh-key:` に差し替え、 `RELEASE_DEPLOY_KEY` secret に登録した private key で checkout する。 checkout action が remote URL を SSH に設定するため、以降の
`git push --follow-tags` は自動で deploy key 経由の push となる。

事前準備の手順は RELEASE_SETUP.md §2-3 を参照。