### PR TITLE
chore: release @minimalcorp/tsunagi v0.0.1

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@minimalcorp/tsunagi",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "Multi-repo GitHub project management with Claude AI integration, designed for visualizing and controlling AI-driven development locally.",
   "keywords": [
     "tsunagi",

--- a/package-lock.json
+++ b/package-lock.json
@@ -254,7 +254,7 @@
     },
     "apps/web": {
       "name": "@minimalcorp/tsunagi",
-      "version": "0.1.0",
+      "version": "0.0.1",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "os": [


### PR DESCRIPTION
ブートストラップ publish (v0.0.1) の version bump を main に反映。