### PR TITLE
fix(prisma): published package に prisma.config.ts を同梱し migration 失敗を修正

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -37,6 +37,7 @@
     "dist/**/*",
     "prisma/schema.prisma",
     "prisma/migrations/**/*",
+    "prisma.config.ts",
     ".next/standalone/**/*",
     "scripts/fix-node-pty-permissions.cjs",
     "tsunagi-marketplace/**/*",

--- a/apps/web/prisma.config.ts
+++ b/apps/web/prisma.config.ts
@@ -1,9 +1,21 @@
 import 'dotenv/config';
+import * as os from 'os';
+import * as path from 'path';
 import { defineConfig } from 'prisma/config';
-import { getDatabasePath } from './src/lib/data-path';
 
-// データベースパスを取得（migrate/studioコマンド用）
-const dbPath = getDatabasePath();
+// NOTE: published package には src/ が含まれないため、src/lib/data-path.ts からの
+// import はできない。同等ロジックをインラインで実装する。
+// 本体ロジック変更時は以下 3 箇所を同期する必要がある:
+//   - src/lib/data-path.ts
+//   - scripts/auto-migrate.ts
+//   - prisma.config.ts
+function getTsunagiDataDir(): string {
+  return process.env.TSUNAGI_DATA_DIR || path.join(os.homedir(), '.tsunagi');
+}
+
+function getDatabasePath(): string {
+  return path.join(getTsunagiDataDir(), 'state', 'tsunagi.db');
+}
 
 export default defineConfig({
   schema: 'prisma/schema.prisma',
@@ -11,6 +23,6 @@ export default defineConfig({
     path: 'prisma/migrations',
   },
   datasource: {
-    url: `file:${dbPath}`,
+    url: `file:${getDatabasePath()}`,
   },
 });

--- a/apps/web/scripts/auto-migrate.ts
+++ b/apps/web/scripts/auto-migrate.ts
@@ -11,10 +11,6 @@ function getTsunagiDataDir(): string {
   return process.env.TSUNAGI_DATA_DIR || path.join(os.homedir(), '.tsunagi');
 }
 
-function getDatabasePath(): string {
-  return path.join(getTsunagiDataDir(), 'state', 'tsunagi.db');
-}
-
 function getStateDir(): string {
   return path.join(getTsunagiDataDir(), 'state');
 }
@@ -23,19 +19,14 @@ async function autoMigrate() {
   try {
     console.log('DB migration started');
 
-    const dbPath = getDatabasePath();
     const stateDir = getStateDir();
 
     // データベースディレクトリが存在しない場合は作成
+    // データベース URL 自体は prisma.config.ts の datasource.url で解決される
+    // (Prisma 7 では schema.prisma の env("DATABASE_URL") は非対応)
     await fs.mkdir(stateDir, { recursive: true });
 
-    // 環境変数を設定してprisma migrate deployを実行
-    const env = {
-      ...process.env,
-      DATABASE_URL: `file:${dbPath}`,
-    };
-
-    const { stdout } = await execAsync('npx prisma migrate deploy', { env });
+    const { stdout } = await execAsync('npx prisma migrate deploy');
 
     // Prismaの出力から重要な行を抽出して表示
     const lines = stdout
@@ -49,7 +40,7 @@ async function autoMigrate() {
 
     // Prisma Clientを生成
     console.log('Generating Prisma Client...');
-    const { stdout: generateOutput } = await execAsync('npx prisma generate', { env });
+    const { stdout: generateOutput } = await execAsync('npx prisma generate');
 
     const generateLines = generateOutput
       .split('\n')


### PR DESCRIPTION
## Summary

- `npm install -g @minimalcorp/tsunagi@0.0.3` 後の `tsunagi` グローバル起動で `datasource.url is required in your Prisma config file` エラーで DB migration が失敗していた問題を修正
- Prisma 7 から `datasource.url` は `schema.prisma` 非対応になり `prisma.config.ts` 側で定義する必要があるが、`apps/web/package.json` の `files` に `prisma.config.ts` が含まれておらず、published tarball に同梱されていなかったのが根本原因
- `prisma.config.ts` を `./src/lib/data-path` 依存からインライン実装へ書き換え（published tarball には `src/` が含まれないため）、`files` に追加

## Changes

- `apps/web/prisma.config.ts`: `./src/lib/data-path` の import を削除し、`getTsunagiDataDir` / `getDatabasePath` をインライン実装。`TSUNAGI_DATA_DIR` 環境変数による override は維持
- `apps/web/package.json`: `files` に `prisma.config.ts` を追加
- `apps/web/scripts/auto-migrate.ts`: 無意味な `DATABASE_URL` env セットを削除（Prisma 7 では `schema.prisma` の `env("DATABASE_URL")` は非対応）。未使用になった `getDatabasePath` 関数も削除

## Notes

- `getDatabasePath` ロジックが `src/lib/data-path.ts` / `scripts/auto-migrate.ts` / `prisma.config.ts` の 3 箇所に重複するが、`prisma.config.ts` が `dist/` build 成果物を import するとビルド前後の順序問題が発生するため重複を許容。10 行未満の単純なパス結合のため将来の統合リファクタリングは別タスクとする
- Prisma 7 は `prisma.config.ts` を `.ts` 拡張子のまま直接サポートするためビルド不要

## Test plan

- [x] `npm run format` 成功
- [x] `npm run lint` 成功
- [x] `npm run type-check` 成功
- [x] `npm pack --dry-run` で tarball に `prisma.config.ts` が含まれることを確認
- [ ] 実際に `npm pack` → 別ディレクトリで `npm install -g ./minimalcorp-tsunagi-*.tgz` → `tsunagi` 起動で DB migration 成功を確認
- [ ] 既存の `npm run dev` / `npm run db:migrate` の動作確認
- [ ] `TSUNAGI_DATA_DIR` による data directory override の動作確認
- [ ] マージ後 Release workflow (target=tsunagi, version=patch) で `v0.0.4` として publish → `npm install -g @minimalcorp/tsunagi@0.0.4 && tsunagi` で動作確認

## Refs

- [Upgrade to Prisma ORM 7](https://www.prisma.io/docs/orm/more/upgrade-guides/upgrading-versions/upgrading-to-prisma-7)
- prisma/prisma#28622 (url is no longer supported in datasource)
- prisma/prisma#28573 (Prisma 7 breaking changes to Prisma config file)