### PR TITLE
ci(release): build shared types and generate Prisma client before npm version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build shared types
+        run: npm run build -w @minimalcorp/tsunagi-shared
+
+      - name: Generate Prisma client (server)
+        run: npm run db:generate -w @minimalcorp/tsunagi-server
+
       - name: Configure git author
         run: |
           git config user.name "github-actions[bot]"
@@ -134,6 +140,8 @@ jobs:
             git tag -a "v${NEW_VERSION}" -m "Release v${NEW_VERSION}"
             # 依存関係が変わっている可能性があるので再 install
             npm ci
+            npm run build -w @minimalcorp/tsunagi-shared
+            npm run db:generate -w @minimalcorp/tsunagi-server
             sleep 2
           done
           echo "::error::Push failed after 3 attempts"


### PR DESCRIPTION
## Summary

- `release.yml` の `publish-tsunagi` ジョブで `npm version` 実行時に husky pre-commit フックが `npm run type-check` を実行し、ビルド成果物が存在しないため型チェックが失敗していた
- `npm ci` の後に `Build shared types` と `Generate Prisma client (server)` の2ステップを追加
- rebase リトライパスの `npm ci` 後にも同じ2コマンドを追加
- `ci.yml` で commit 7e0f412 に適用済みの修正を `release.yml` にも反映

## Test plan

- [ ] `workflow_dispatch` で release workflow を手動実行（`patch` bump）し、`Bump version` ステップが成功することを確認
- [ ] push 失敗時のリトライパスも目視レビューで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)