### PR TITLE
fix: Monaco editor close 後の xterm 余白問題を修正

### DIFF
--- a/apps/server/src/editor-session-store.ts
+++ b/apps/server/src/editor-session-store.ts
@@ -3,6 +3,7 @@ interface EditorSession {
   content: string;
   status: 'pending' | 'done';
   createdAt: number;
+  tabId: string | null;
 }
 
 export const editorSessionStore = new Map<string, EditorSession>();

--- a/apps/server/src/routes/editor.ts
+++ b/apps/server/src/routes/editor.ts
@@ -34,6 +34,7 @@ export async function editorRoutes(fastify: FastifyInstance) {
         content,
         status: 'pending',
         createdAt: Date.now(),
+        tabId: tabId ?? null,
       });
 
       // tabIdが指定されていれば、最後にinputを送信したソケットにのみ送信
@@ -74,6 +75,26 @@ export async function editorRoutes(fastify: FastifyInstance) {
       }
       await writeFile(session.filePath, request.body.content, 'utf8');
       session.status = 'done';
+
+      // sh が polling で "done" を検知して exit し claude が foreground に戻った後、
+      // cols を一瞬変えることで SIGWINCH を発火させる。
+      // rows 変更と異なり cols 変更では Ink が全画面クリア + 全 UI 再描画を行うため、
+      // $EDITOR exit 後に blank になる余白が解消される。
+      // 300ms: server が /complete を受信した時点が T=0。sh の polling(最大100ms) +
+      //        exit + claude foreground 復帰 で ~150ms。余裕を持たせた値。
+      if (session.tabId) {
+        const ptySession = ptyManager.getSession(session.tabId);
+        if (ptySession) {
+          const { cols, rows } = ptySession.pty;
+          setTimeout(() => {
+            ptySession.pty.resize(cols + 1, rows);
+            setTimeout(() => {
+              ptySession.pty.resize(cols, rows);
+            }, 100);
+          }, 300);
+        }
+      }
+
       return reply.send({ ok: true });
     }
   );

--- a/apps/web/src/components/TerminalView.tsx
+++ b/apps/web/src/components/TerminalView.tsx
@@ -195,6 +195,16 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
       return true;
     });
 
+    // alt screen (1049) から main screen に復帰した際、xterm.js は内部バッファを切り替えるが
+    // キャンバスの再描画は変更があった行のみに最適化されているため、上部の行が再描画されず
+    // 余白として見える問題がある（ネイティブターミナルでは発生しない xterm.js 固有の挙動）。
+    // onBufferChange で normal buffer への切り替えを検知し、refresh() で全行を強制再描画する。
+    term.buffer.onBufferChange((buf) => {
+      if (buf.type === 'normal') {
+        term.refresh(0, term.rows - 1);
+      }
+    });
+
     // xterm.js は CompositionHelper 内で composition 中のキーストロークを内部で抑制し、
     // compositionend 後の setTimeout で確定テキストのみ triggerDataEvent → onData で通知する。
     // そのため我々が compositionstart/end を監視して onData をガードする必要はない。
@@ -243,35 +253,6 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
     }
     function handleEditorSessionDone() {
       isExternalEditorOpenRef.current = false;
-      // claude 2.1.94 は $EDITOR 終了後に Ink の内部状態と実画面の position がズレて
-      // 余白が発生する。実ブラウザリサイズでは直ることを確認済みなので、
-      // プログラム側から疑似的な dimension 変化 (bump-then-restore) を注入して
-      // Node.js の 'resize' event → Ink の full re-layout を強制発火させる。
-      //
-      // 注意点:
-      // - Node.js の 'resize' event は process.stdout の cols/rows が実際に
-      //   変化した時のみ発火するため、同サイズ resize では効かない。
-      // - 200ms 遅延: monaco-editor.sh が polling から exit して foreground PG が
-      //   claude に戻るのを待つ。sh が前景にいる間に resize すると SIGWINCH が
-      //   sh に届いてしまう。
-      // - rows+1: 一瞬増やす方向にすることで、入力欄が画面外に押し出される
-      //   flicker を避ける (rows-1 だと入力欄が 1 行上に動くのが見える)。
-      // - 30ms の間隔: 2 回の resize を別 tick で処理させて、Node 側で集約され
-      //   てしまうのを防ぐ。
-      setTimeout(() => {
-        const socket = socketRef.current;
-        const sid = sessionIdRef.current;
-        const term = termRef.current;
-        if (!socket?.connected || !sid || !term) return;
-        socket.emit('resize', { sessionId: sid, cols: term.cols, rows: term.rows + 1 });
-        setTimeout(() => {
-          const t = termRef.current;
-          const s = socketRef.current;
-          if (s?.connected && sid && t) {
-            s.emit('resize', { sessionId: sid, cols: t.cols, rows: t.rows });
-          }
-        }, 30);
-      }, 200);
       // アクティブタブのみフォーカスを復帰する
       if (!isActiveRef.current) return;
       // xterm 内の textarea を直接 focus する（Terminal.focus() では効かない）


### PR DESCRIPTION
## 概要

Ctrl+G で Monaco editor を開いて閉じた後、xterm の表示に余白が入る問題を修正。

- 入力値は正しく claude に反映されるが、会話履歴エリアが blank になる
- ブラウザ resize で正しく再描画される

## 原因

Ink（Claude Code の UI ライブラリ）は SIGWINCH 受信時、変更内容によって動作が異なる。

| SIGWINCH の内容 | Ink の動作 |
|---|---|
| rows のみ変更 | 部分更新（go up N + clear + write） |
| **cols 変更** | **全画面クリア + 全 UI 再描画** |

これまでの修正（rows bump）では部分更新しか発火されず、blank になった viewport 上部が再描画されなかった。ブラウザ resize が効くのは必ず cols も変わるため。

また、alt screen 復帰時に xterm.js がキャンバスを部分的にしか再描画しない問題も別途存在する（`onBufferChange → refresh()` で対処）。

## 修正内容

### `apps/server/src/routes/editor.ts`
`/api/editor/session/:id/complete` で完了後、PTY に cols+1 → cols の bump-then-restore resize を注入。

```
T=0    : server が /complete を受信、file 書き戻し、session を done に
T=300ms: ptyProcess.resize(cols+1, rows)  ← SIGWINCH(cols 変更) → Ink 全画面 re-render
T=400ms: ptyProcess.resize(cols, rows)    ← 元に戻す
```

### `apps/server/src/editor-session-store.ts`
PTY session 特定のため `tabId` を EditorSession に追加。

### `apps/web/src/components/TerminalView.tsx`
alt screen 復帰時の xterm.js キャンバス未描画を `onBufferChange → refresh()` で対処。

## 検証
- Ctrl+G → 複数行テキスト入力 → Cmd+Enter Submit ✓
- Ctrl+G → 複数行テキスト入力 → Esc / Backdrop / Cancel ✓
- 1行テキストでも正常動作（regression なし）✓