### PR TITLE
fix(cli): add process.on('exit') fallback to ensure plugin cleanup on Ctrl+C

### DIFF
--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -110,6 +110,9 @@ function shutdown(code: number): void {
 
 process.on('SIGINT', () => shutdown(0));
 process.on('SIGTERM', () => shutdown(0));
+process.on('exit', () => {
+  if (!shuttingDown) cleanupPluginState();
+});
 
 fastifyChild.on('exit', (code) => {
   console.error(`[tsunagi] Fastify server exited with code ${code}`);


### PR DESCRIPTION
## Summary

- `single-instance-lock.ts` の SIGINT ハンドラが先に `process.exit(0)` を呼ぶことで、`cli.ts` の SIGINT ハンドラ（`cleanupPluginState()`）が実行されない問題を修正
- `process.on('exit', ...)` フォールバックハンドラを追加することで、どのハンドラが先に `process.exit()` を呼んでもクリーンアップを保証
- `with-plugin.ts` で既に使われている同一パターンを `cli.ts` にも適用

## Root cause

1. `acquireSingleInstanceLock()` が先に呼ばれ SIGINT ハンドラを登録（`single-instance-lock.ts:88-91`）
2. Ctrl+C 時、`single-instance-lock` のハンドラが先に実行: `releaseLock(); process.exit(0)`
3. `process.exit(0)` で即座に終了シーケンスへ移行 → `cli.ts` の SIGINT ハンドラは実行されない
4. `exit` イベントは `process.exit()` 呼び出し時に必ず発火するため、フォールバックとして機能する

## Test plan

- [x] format / lint / type-check すべて pass
- [x] `npm run build:dist` でビルドし、ビルド成果物を直接実行後 Ctrl+C でプラグインが uninstall されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)