### PR TITLE
fix: 起動時のplugin uninstallエラー出力を正常系では非表示にする

### DIFF
--- a/apps/cli/src/plugin-lifecycle.ts
+++ b/apps/cli/src/plugin-lifecycle.ts
@@ -40,6 +40,26 @@ function log(msg: string): void {
   console.log(`[tsunagi:plugin] ${msg}`);
 }
 
+/** プラグインがインストール済みか確認する */
+function isPluginInstalled(): boolean {
+  try {
+    const output = execSync('claude plugin list', { stdio: 'pipe' }).toString();
+    return output.includes(PLUGIN_REF);
+  } catch {
+    return false;
+  }
+}
+
+/** marketplaceが登録済みか確認する */
+function isMarketplaceAdded(): boolean {
+  try {
+    const output = execSync('claude plugin marketplace list', { stdio: 'pipe' }).toString();
+    return output.includes(MARKETPLACE_NAME);
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Run a `claude` CLI command. Returns true on success, false on failure.
  * Logs stderr on failure to aid debugging.
@@ -64,8 +84,13 @@ function runClaude(args: string): boolean {
  */
 export function ensureCleanPluginState(): void {
   // Phase 1: best-effort cleanup of any orphaned state from a previous run.
-  runClaude(`plugin uninstall ${PLUGIN_REF}`);
-  runClaude(`plugin marketplace remove ${MARKETPLACE_NAME}`);
+  // Check existence first to avoid error output when plugin is not installed (normal first-boot case).
+  if (isPluginInstalled()) {
+    runClaude(`plugin uninstall ${PLUGIN_REF}`);
+  }
+  if (isMarketplaceAdded()) {
+    runClaude(`plugin marketplace remove ${MARKETPLACE_NAME}`);
+  }
 
   // Phase 2: clean install. Failures here are fatal.
   const marketplaceDir = getMarketplaceDir();


### PR DESCRIPTION
## Summary

- `ensureCleanPluginState()` の Phase 1 で、プラグイン/マーケットプレイスの存在を確認してから cleanup を実行するよう変更
- `isPluginInstalled()` / `isMarketplaceAdded()` 関数を追加し、存在しない場合は uninstall/remove をスキップ
- 初回起動（正常系）でエラーログが出なくなる。クラッシュ後の再起動（異常系）では従来通り uninstall → install が実行される

## Test plan

- [x] tsunagi 未起動の状態で `npm run dev` → `plugin uninstall` のエラーログが表示されないことを確認
- [ ] 手動で `claude plugin install tsunagi-plugin@tsunagi-marketplace --scope user` してから `npm run dev` → uninstall 後に install が実行されることを確認
- [x] 起動後に `claude plugin list` でプラグインが正常にインストールされていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)