### PR TITLE
fix: release.yml の deploy-docs にバージョンbump・commit・tag pushを追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,7 +174,7 @@ jobs:
     needs: approve
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pages: write
       id-token: write
     environment:
@@ -183,6 +183,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -192,6 +195,46 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Configure git author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump version (docs)
+        id: bump
+        run: |
+          npm version "${{ inputs.version }}" --workspace=tsunagi-docs
+          NEW_VERSION=$(node -p "require('./apps/docs/package.json').version")
+          echo "new_version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
+          git add apps/docs/package.json package-lock.json
+          git commit -m "chore: release tsunagi-docs v${NEW_VERSION}"
+          git tag -a "docs-v${NEW_VERSION}" -m "Release docs-v${NEW_VERSION}"
+
+      - name: Push commit and tag (with rebase retry)
+        env:
+          NEW_VERSION: ${{ steps.bump.outputs.new_version }}
+        run: |
+          set -u
+          for attempt in 1 2 3; do
+            if git push --atomic --follow-tags; then
+              echo "Push succeeded on attempt ${attempt}"
+              exit 0
+            fi
+            echo "::warning::Push failed on attempt ${attempt}. Attempting rebase..."
+            git tag -d "docs-v${NEW_VERSION}" || true
+            git fetch origin main
+            if ! git rebase origin/main; then
+              echo "::error::Rebase conflict with origin/main. Aborting."
+              git rebase --abort || true
+              exit 1
+            fi
+            git tag -a "docs-v${NEW_VERSION}" -m "Release docs-v${NEW_VERSION}"
+            npm ci
+            sleep 2
+          done
+          echo "::error::Push failed after 3 attempts"
+          exit 1
 
       - name: Configure GitHub Pages
         id: pages


### PR DESCRIPTION
## Summary

- `deploy-docs` ジョブで `apps/docs/package.json` のバージョンが `0.0.0` のままになっていた問題を修正
- `publish-tsunagi` と同様のバージョンbump・commit・tag push ロジックを追加

## Changes

| 変更点 | 内容 |
|--------|------|
| `permissions.contents` | `read` → `write` |
| `Checkout` | `fetch-depth: 0` + `ssh-key: RELEASE_DEPLOY_KEY` を追加 |
| `Configure git author` | 新規ステップ（bot メール設定） |
| `Bump version (docs)` | `--workspace=tsunagi-docs` でbump、commit、`docs-v*` タグ作成 |
| `Push commit and tag (with rebase retry)` | `publish-tsunagi` と同一の3回リトライロジック |

ステップ順序: Install deps → Configure git author → Bump version → Push → Configure GitHub Pages → Build → Upload → Deploy

## Test plan

- [ ] `target=docs`, `version=patch` で workflow を実行し `apps/docs/package.json` の version が bump されることを確認
- [ ] `docs-v0.0.1` タグが push されることを確認
- [ ] GitHub Pages が正常にデプロイされることを確認
- [ ] `target=all` で workflow を実行し tsunagi/docs 両方が正常にリリースされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)