### PR TITLE
fix: CI lint/type-check カバレッジの整備

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,4 @@
+npm run build -w @minimalcorp/tsunagi-shared
+npm run db:generate -w @minimalcorp/tsunagi-server
 npx lint-staged
 npm run type-check

--- a/apps/docs/eslint.config.mjs
+++ b/apps/docs/eslint.config.mjs
@@ -1,0 +1,16 @@
+import { defineConfig, globalIgnores } from 'eslint/config';
+import prettier from 'eslint-config-prettier';
+
+const eslintConfig = defineConfig([
+  {
+    languageOptions: {
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+      },
+    },
+  },
+  prettier,
+  globalIgnores(['.next/**', 'out/**', 'build/**', 'next-env.d.ts', 'dist/**']),
+]);
+
+export default eslintConfig;

--- a/apps/docs/mdx-components.js
+++ b/apps/docs/mdx-components.js
@@ -15,10 +15,7 @@ function Screenshot({ src, alt }) {
     typeof src === 'string' && src.startsWith('/') && !src.startsWith('//')
       ? `${basePath}${src}`
       : src;
-  return (
-    // eslint-disable-next-line @next/next/no-img-element
-    <img src={resolved} alt={alt} style={{ maxWidth: '100%', maxHeight: '80vh' }} />
-  );
+  return <img src={resolved} alt={alt} style={{ maxWidth: '100%', maxHeight: '80vh' }} />;
 }
 
 export function useMDXComponents(components) {

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -7,6 +7,7 @@
     "dev": "next dev --port 2793",
     "build": "next build",
     "start": "next start --port 2793",
+    "lint": "eslint",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
@@ -20,6 +21,8 @@
     "@types/node": "^20.19.30",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "eslint": "^9",
+    "eslint-config-prettier": "^10.1.8",
     "typescript": "^5.9.3"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,6 +75,8 @@
         "@types/node": "^20.19.30",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
+        "eslint": "^9",
+        "eslint-config-prettier": "^10.1.8",
         "typescript": "^5.9.3"
       }
     },
@@ -19193,6 +19195,8 @@
       "name": "@minimalcorp/tsunagi-shared",
       "version": "0.0.0",
       "devDependencies": {
+        "eslint": "^9",
+        "eslint-config-prettier": "^10.1.8",
         "typescript": "^5.9.3"
       }
     }

--- a/packages/shared/eslint.config.mjs
+++ b/packages/shared/eslint.config.mjs
@@ -1,0 +1,6 @@
+import { defineConfig, globalIgnores } from 'eslint/config';
+import prettier from 'eslint-config-prettier';
+
+const eslintConfig = defineConfig([prettier, globalIgnores(['dist/**'])]);
+
+export default eslintConfig;

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -19,9 +19,12 @@
   "scripts": {
     "build": "tsc",
     "clean": "rm -rf dist",
+    "lint": "eslint",
     "type-check": "tsc --noEmit"
   },
   "devDependencies": {
+    "eslint": "^9",
+    "eslint-config-prettier": "^10.1.8",
     "typescript": "^5.9.3"
   }
 }


### PR DESCRIPTION
## Summary

- `.husky/pre-commit` に shared のビルドと Prisma client 生成を追加し、artifacts が未生成でも `npm run type-check` が通るようにした
- `apps/docs` / `packages/shared` に `lint` スクリプトと `eslint.config.mjs` を追加し、`npm run lint --workspaces` のカバレッジ漏れを解消した

## Changes

### `.husky/pre-commit`

build artifacts に依存する type-check が失敗しないよう、コミット前に shared のビルドと Prisma generate を実行するように変更。

```sh
npm run build -w @minimalcorp/tsunagi-shared
npm run db:generate -w @minimalcorp/tsunagi-server
npx lint-staged
npm run type-check
```

### `apps/docs` / `packages/shared`

| workspace | 変更内容 |
|---|---|
| docs | `lint: "eslint"` スクリプト追加、`eslint.config.mjs` 新規作成 |
| shared | `lint: "eslint"` スクリプト追加、`eslint.config.mjs` 新規作成 |

`eslint-config-next@15` は legacy config 形式で ESLint 9 flat config 非対応のため、`docs` は server/cli と同様の prettier ベース設定を採用。

## Test plan

- [x] `npm run lint` — 全 workspace (cli, server, web, docs, shared) で lint 実行を確認
- [x] `npm run type-check` — 全 workspace で型チェック通過を確認
- [x] pre-commit フック — `git commit` 時に build → lint-staged → type-check が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)