### PR TITLE
fix: session終了時にtab.todosをクリアしてプログレスバーの分母不正を修正

### DIFF
--- a/apps/server/prisma/migrations/20260410000000_clear_stale_tab_todos/migration.sql
+++ b/apps/server/prisma/migrations/20260410000000_clear_stale_tab_todos/migration.sql
@@ -1,0 +1,4 @@
+-- session 終了時の todos クリア漏れで蓄積した stale データを一括リセット
+-- idle/error 状態のタブは次回セッション開始まで参照されないため安全にクリアできる
+-- success 状態（Stop 正常完了）のタブは累積プログレス表示のため意図的に残す
+UPDATE "tabs" SET todos = '[]' WHERE status IN ('idle', 'error');

--- a/apps/server/src/routes/hooks.ts
+++ b/apps/server/src/routes/hooks.ts
@@ -41,16 +41,19 @@ export const hookEvents: HookEvent[] = [];
 interface TaskEntry {
   id: string;
   subject: string;
-  status: 'pending' | 'in_progress' | 'completed';
+  status: 'pending' | 'in_progress' | 'completed' | 'deleted';
 }
 
 const sessionTasks = new Map<string, Map<string, TaskEntry>>();
 
-/** TaskEntryリストをTodo形式に変換 */
+/**
+ * TaskEntryリストをTodo形式に変換。
+ * 'deleted' を含めて全 status を pass-through し、表示時のフィルタは frontend 側に任せる。
+ */
 function tasksToTodos(tasks: Map<string, TaskEntry>) {
   return Array.from(tasks.values()).map((t) => ({
     content: t.subject,
-    status: t.status === 'in_progress' ? ('in_progress' as const) : t.status,
+    status: t.status,
   }));
 }
 
@@ -160,16 +163,23 @@ export async function hooksRoutes(fastify: FastifyInstance) {
             }
           }
 
-          // TaskUpdate: タスクのステータスを更新
+          // TaskUpdate: タスクのステータスを更新（'deleted' 含む。Mapからは除去せず保持し、表示層で除外）
           if (body.tool_name === 'TaskUpdate' && body.tool_response && body.tool_input) {
             const taskId = body.tool_input.taskId as string | undefined;
-            const statusChange = body.tool_response.statusChange as { to: string } | undefined;
+            // tool_input.status を優先（直接入力なので確実）、フォールバックで tool_response.statusChange.to
+            const newStatus =
+              (body.tool_input.status as string | undefined) ??
+              (body.tool_response.statusChange as { to: string } | undefined)?.to;
             const tasks = sessionTasks.get(sessionId);
-            if (tasks && taskId && statusChange?.to) {
+            if (tasks && taskId && newStatus) {
               const entry = tasks.get(taskId);
               if (entry) {
-                entry.status = statusChange.to as TaskEntry['status'];
+                entry.status = newStatus as TaskEntry['status'];
                 const todos = tasksToTodos(tasks);
+                fastify.log.info(
+                  { sessionId, taskId, newStatus, mapSize: tasks.size },
+                  '[hooks] TaskUpdate processed'
+                );
                 await updateTabStatus(sessionId, 'running', todos);
                 io.to(room).emit('todos-updated', { sessionId, todos });
                 todosUpdated = true;

--- a/apps/server/src/routes/hooks.ts
+++ b/apps/server/src/routes/hooks.ts
@@ -59,17 +59,19 @@ async function updateTabStatus(
   sessionId: string,
   status: string,
   todos?: unknown[]
-): Promise<void> {
+): Promise<{ count: number }> {
   try {
-    await prisma.tab.updateMany({
+    const result = await prisma.tab.updateMany({
       where: { tabId: sessionId },
       data: {
         status,
         ...(todos !== undefined && { todos: JSON.stringify(todos) }),
       },
     });
+    return { count: result.count };
   } catch (err) {
     console.warn(`[hooks] Failed to update tab status in DB:`, err);
+    return { count: 0 };
   }
 }
 
@@ -125,7 +127,15 @@ export async function hooksRoutes(fastify: FastifyInstance) {
               status: 'pending' | 'in_progress' | 'completed';
             }>;
             if (Array.isArray(todos)) {
-              await updateTabStatus(sessionId, 'running', todos);
+              fastify.log.info(
+                { sessionId, todosCount: todos.length },
+                '[hooks] TodoWrite received'
+              );
+              const { count } = await updateTabStatus(sessionId, 'running', todos);
+              fastify.log.info(
+                { sessionId, updatedTabCount: count },
+                '[hooks] TodoWrite tab updated'
+              );
               io.to(room).emit('todos-updated', { sessionId, todos });
               todosUpdated = true;
             }
@@ -185,17 +195,19 @@ export async function hooksRoutes(fastify: FastifyInstance) {
           break;
 
         case 'StopFailure':
-          // APIエラーでターン終了 → failure状態に更新
-          await updateTabStatus(sessionId, 'error');
+          // APIエラーでターン終了 → failure状態に更新、todosをクリア
+          await updateTabStatus(sessionId, 'error', []);
           io.to(room).emit('status-changed', { sessionId, status: 'failure' });
+          io.to(room).emit('todos-updated', { sessionId, todos: [] });
           break;
 
         case 'SessionEnd':
-          // セッション終了（Escキー中断・Ctrl+C・/exit等）→ idle状態に更新
+          // セッション終了（Escキー中断・Ctrl+C・/exit等）→ idle状態に更新、todosをクリア
           // reason: "prompt_input_exit" = ユーザー中断、"other" = プロセスkill等
           fastify.log.info({ sessionId, reason: body.reason }, 'SessionEnd received');
-          await updateTabStatus(sessionId, 'idle');
+          await updateTabStatus(sessionId, 'idle', []);
           io.to(room).emit('status-changed', { sessionId, status: 'idle' });
+          io.to(room).emit('todos-updated', { sessionId, todos: [] });
           break;
 
         default:

--- a/apps/server/src/routes/terminal.ts
+++ b/apps/server/src/routes/terminal.ts
@@ -81,12 +81,13 @@ export async function terminalRoutes(fastify: FastifyInstance) {
       // PTYプロセス終了 → room全体に通知（全接続クライアントに終了を伝える）+ セッション削除
       const exitHandler = ptyProcess.onExit(({ exitCode }: { exitCode: number }) => {
         io.to(room).emit('exit', { exitCode });
-        // Ctrl+C等でClaudeが強制終了した場合にclaudeStatusをidleにリセット
+        // Ctrl+C等でClaudeが強制終了した場合にclaudeStatusをidleにリセット、todosをクリア
         io.to(room).emit('status-changed', { sessionId, status: 'idle' });
+        io.to(room).emit('todos-updated', { sessionId, todos: [] });
         prisma.tab
           .updateMany({
             where: { tabId: sessionId },
-            data: { status: 'idle' },
+            data: { status: 'idle', todos: '[]' },
           })
           .catch(() => {
             /* DB更新失敗は無視 */

--- a/apps/web/src/components/TaskCard.tsx
+++ b/apps/web/src/components/TaskCard.tsx
@@ -9,7 +9,7 @@ import { Progress } from '@/components/ui/progress';
 
 export interface TabTodo {
   content: string;
-  status: 'pending' | 'in_progress' | 'completed';
+  status: 'pending' | 'in_progress' | 'completed' | 'deleted';
 }
 
 interface TaskCardProps {
@@ -33,10 +33,12 @@ export function TaskCard({ task, isDragging, dragHandleProps, tabTodosMap }: Tas
     .filter((tab) => tab !== runningTab)
     .flatMap((tab) => tab.todos ?? []);
   const allTodos = [...nonRunningTodos, ...runningTodos];
-  const completedTodos = allTodos.filter((t) => t.status === 'completed').length;
-  const totalTodos = allTodos.length;
+  // 表示層で 'deleted' を除外して分母・完了数を計算（データ層には保持したまま）
+  const visibleTodos = allTodos.filter((t) => t.status !== 'deleted');
+  const completedTodos = visibleTodos.filter((t) => t.status === 'completed').length;
+  const totalTodos = visibleTodos.length;
   const showProgressBar = totalTodos > 0;
-  const currentTodo = allTodos.find((t) => t.status === 'in_progress');
+  const currentTodo = visibleTodos.find((t) => t.status === 'in_progress');
 
   const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     // ドラッグ中はリンク遷移を防止

--- a/apps/web/src/components/TaskCard.tsx
+++ b/apps/web/src/components/TaskCard.tsx
@@ -24,10 +24,15 @@ export function TaskCard({ task, isDragging, dragHandleProps, tabTodosMap }: Tas
   const tabs = task.tabs || [];
   const isClaudeRunning = tabs.some((tab) => tab.status === 'running');
 
-  // リアルタイムのtabTodosMapがあればそちらを優先、なければDB todosにフォールバック
+  // running タブの todos（リアルタイム優先、なければDB）と非running タブの todos（DB）をマージ
+  // → Session1(7/7完了) の後に Session2(3件追加) を開始した場合に (7/10) → (10/10) と表示される
   const runningTab = tabs.find((tab) => tab.status === 'running');
   const realtimeTodos = runningTab && tabTodosMap ? tabTodosMap.get(runningTab.tab_id) : undefined;
-  const allTodos = realtimeTodos ?? tabs.flatMap((tab) => tab.todos ?? []);
+  const runningTodos: TabTodo[] = realtimeTodos ?? runningTab?.todos ?? [];
+  const nonRunningTodos = tabs
+    .filter((tab) => tab !== runningTab)
+    .flatMap((tab) => tab.todos ?? []);
+  const allTodos = [...nonRunningTodos, ...runningTodos];
   const completedTodos = allTodos.filter((t) => t.status === 'completed').length;
   const totalTodos = allTodos.length;
   const showProgressBar = totalTodos > 0;

--- a/apps/web/src/components/TerminalView.tsx
+++ b/apps/web/src/components/TerminalView.tsx
@@ -25,7 +25,7 @@ export type ClaudeStatus = 'idle' | 'running' | 'waiting' | 'success' | 'failure
 
 export interface Todo {
   content: string;
-  status: 'pending' | 'in_progress' | 'completed';
+  status: 'pending' | 'in_progress' | 'completed' | 'deleted';
 }
 
 interface TerminalViewProps {
@@ -505,8 +505,10 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
   const isPausedOrExited = status === 'paused' || status === 'exited' || status === 'error';
   const isConnected = status === 'connected';
 
-  const completedTodos = todos.filter((t) => t.status === 'completed').length;
-  const totalTodos = todos.length;
+  // 表示層で 'deleted' を除外して分母・完了数を計算
+  const visibleTodos = todos.filter((t) => t.status !== 'deleted');
+  const completedTodos = visibleTodos.filter((t) => t.status === 'completed').length;
+  const totalTodos = visibleTodos.length;
 
   // 短縮表示用UUID（先頭8文字 + …）
   const shortTabId = tabId.length > 8 ? `${tabId.slice(0, 8)}…` : tabId;

--- a/apps/web/src/components/planner/TaskCard.tsx
+++ b/apps/web/src/components/planner/TaskCard.tsx
@@ -76,8 +76,10 @@ export function TaskCard({ task, dragHandleProps }: TaskCardProps) {
   const repoColor = getRepoColor(task.owner, task.repo);
   const isClaudeRunning = (task.tabs ?? []).some((t) => t.status === 'running');
 
-  // タブのtodosからプログレスを計算（DB永続化済み）
-  const allTodos = (task.tabs ?? []).flatMap((tab) => tab.todos ?? []);
+  // タブのtodosからプログレスを計算（DB永続化済み）。'deleted' は表示層で除外
+  const allTodos = (task.tabs ?? [])
+    .flatMap((tab) => tab.todos ?? [])
+    .filter((t) => t.status !== 'deleted');
   const completedTodos = allTodos.filter((t) => t.status === 'completed').length;
   const totalTodos = allTodos.length;
   const shortId = task.id.slice(0, 5) + '\u2026';

--- a/apps/web/src/hooks/useTerminalTodos.ts
+++ b/apps/web/src/hooks/useTerminalTodos.ts
@@ -6,7 +6,7 @@ import { getServerUrl } from '@/lib/api-url';
 
 export interface Todo {
   content: string;
-  status: 'pending' | 'in_progress' | 'completed';
+  status: 'pending' | 'in_progress' | 'completed' | 'deleted';
 }
 
 /** タブIDをキーにしたTodosのMap */

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -24,10 +24,11 @@ export interface Task {
   worktreePath?: string; // worktreeのフルパス（APIから返される）
 }
 
-// Todo型（Claude TodoWrite hook由来）
+// Todo型（Claude TodoWrite / TaskCreate / TaskUpdate hook由来）
+// 'deleted' はデータ層で保持し、表示層（progress bar等）で除外する
 export interface Todo {
   content: string;
-  status: 'pending' | 'in_progress' | 'completed';
+  status: 'pending' | 'in_progress' | 'completed' | 'deleted';
 }
 
 // Tab型（タブとメッセージ履歴を分離）


### PR DESCRIPTION
## Summary

- `SessionEnd` / `StopFailure` hook 受信時に `tab.todos` を空配列でクリアし、`todos-updated` イベントをemit（従来は `status` のみ更新でtodosが残存していた）
- PTY exit ハンドラ（Ctrl+C等の強制終了）でも `todos: '[]'` をDBに書き込み、`todos-updated` をemit
- ボード `TaskCard` の `allTodos` 計算を「非runningタブ(DB) + runningタブ(realtime/DB)」のマージ方式に変更し、複数セッション間の累積プログレス表示（Session1: 7/7 → Session2開始: 7/10 → Session2完了: 10/10）を正しく実現
- マイグレーションで既存の `idle`/`error` タブに残存するstale todosを一括クリア
- `Stop`（正常完了）時のtodosは意図的に保持し、次セッションの累積ベースとして利用

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `apps/server/src/routes/hooks.ts` | `SessionEnd`/`StopFailure` でtodosクリア + TodoWrite観測ログ追加 |
| `apps/server/src/routes/terminal.ts` | PTY exit時にtodosクリア |
| `apps/web/src/components/TaskCard.tsx` | allTodosを累積マージ方式に変更 |
| `apps/server/prisma/migrations/20260410000000_clear_stale_tab_todos/migration.sql` | 既存stale todosの一括クリア |

## Test plan

- [ ] 新規タスクでClaudeを起動し、5個のtodoを作成して1個完了 → `1/5` を確認
- [ ] Escキーでセッション中断 → プログレスバーが非表示（0件）になることを確認
- [ ] 同じタブで再度Claudeを起動し、3個のtodoを作成 → `0/3` で正しく表示されることを確認
- [ ] Stop（正常完了）後に次のセッションを開始し、追加todoを作成 → `7/10` のように累積表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)