### PR TITLE
fix: fastify-socket.io を除去し socket.io を直接統合 (Fastify 5 互換)

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -63,7 +63,6 @@
     "concurrently": "^9.2.1",
     "dotenv": "^17.2.3",
     "fastify": "^5.8.2",
-    "fastify-socket.io": "^5.1.0",
     "node-pty": "^1.1.0",
     "prisma": "^7.3.0",
     "simple-git": "^3.30.0",

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -30,7 +30,6 @@
     "@prisma/client": "^7.3.0",
     "dotenv": "^17.2.3",
     "fastify": "^5.8.2",
-    "fastify-socket.io": "^5.1.0",
     "node-pty": "^1.1.0",
     "prisma": "^7.3.0",
     "simple-git": "^3.30.0",

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,12 +1,6 @@
-import Fastify, { type FastifyPluginAsync, type FastifyPluginOptions } from 'fastify';
+import Fastify from 'fastify';
 import fastifyCors from '@fastify/cors';
-import * as fastifySocketIONs from 'fastify-socket.io';
-const fastifySocketIO = ((
-  fastifySocketIONs as unknown as {
-    default?: FastifyPluginAsync<FastifyPluginOptions>;
-  }
-).default ??
-  (fastifySocketIONs as unknown as FastifyPluginAsync<FastifyPluginOptions>)) as FastifyPluginAsync<FastifyPluginOptions>;
+import { Server as SocketIOServer } from 'socket.io';
 
 import { tasksRoutes } from './routes/tasks.js';
 import { reposRoutes } from './routes/repos.js';
@@ -37,12 +31,11 @@ async function start() {
     methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
   });
 
-  await fastify.register(fastifySocketIO, {
+  const io = new SocketIOServer(fastify.server, {
     transports: ['websocket'],
-    cors: {
-      origin: corsOrigins,
-    },
+    cors: { origin: corsOrigins },
   });
+  fastify.decorate('io', io);
 
   await fastify.register(tasksRoutes, { prefix: '/api' });
   await fastify.register(reposRoutes, { prefix: '/api' });

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,6 @@
         "concurrently": "^9.2.1",
         "dotenv": "^17.2.3",
         "fastify": "^5.8.2",
-        "fastify-socket.io": "^5.1.0",
         "node-pty": "^1.1.0",
         "prisma": "^7.3.0",
         "simple-git": "^3.30.0",
@@ -306,7 +305,6 @@
         "@prisma/client": "^7.3.0",
         "dotenv": "^17.2.3",
         "fastify": "^5.8.2",
-        "fastify-socket.io": "^5.1.0",
         "node-pty": "^1.1.0",
         "prisma": "^7.3.0",
         "simple-git": "^3.30.0",
@@ -10010,26 +10008,6 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
-      "license": "MIT"
-    },
-    "node_modules/fastify-socket.io": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/fastify-socket.io/-/fastify-socket.io-5.1.0.tgz",
-      "integrity": "sha512-GC1gjrxBGeTbMWV779XHF4uw3AtgKwSQJ9MnjGiMp91ZBuPXEdBYa7NnAMDEl3oZPgK9JO4BlNncTV+UAN+1kg==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "fastify-plugin": "^4.5.1",
-        "tslib": "^2.6.1"
-      },
-      "peerDependencies": {
-        "fastify": "4.x.x",
-        "socket.io": ">=4"
-      }
-    },
-    "node_modules/fastify-socket.io/node_modules/fastify-plugin": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-4.5.1.tgz",
-      "integrity": "sha512-stRHYGeuqpEZTL1Ef0Ovr2ltazUT9g844X5z/zEBFLG8RYlpDiOCIG+ATvYEp+/zmc7sN29mcIMp8gvYplYPIQ==",
       "license": "MIT"
     },
     "node_modules/fastify/node_modules/semver": {


### PR DESCRIPTION
## Summary

- `fastify-socket.io` を削除し、`socket.io` Server を `fastify.server` に直接アタッチする方式に置換
- `fastify-socket.io` は Fastify 4.x.x のみ対応かつ preinstall で pnpm を強制するため、`npm i -g` でのインストールが失敗していた
- `fastify.decorate('io', io)` により既存ルートの `(fastify as FastifyWithIO).io` アクセスは変更不要

## Test plan

- [x] タスク作成時にリアルタイムで UI に反映されることを確認
- [x] format / lint / type-check 全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)