### PR TITLE
fix: npm i -g 環境で Ctrl+G Monaco Editor が開かない

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -41,6 +41,7 @@
     "prisma.config.ts",
     ".next/standalone/**/*",
     "scripts/fix-node-pty-permissions.cjs",
+    "scripts/monaco-editor.sh",
     "tsunagi-marketplace/**/*",
     "LICENSE",
     "README.md"

--- a/apps/cli/scripts/bundle.mjs
+++ b/apps/cli/scripts/bundle.mjs
@@ -77,7 +77,10 @@ async function cleanCliBundleDirs() {
     path.join(CLI_DIR, '.next'),
     path.join(CLI_DIR, 'prisma'),
   ];
-  const files = [path.join(CLI_DIR, 'prisma.config.ts')];
+  const files = [
+    path.join(CLI_DIR, 'prisma.config.ts'),
+    path.join(CLI_DIR, 'scripts/monaco-editor.sh'),
+  ];
   for (const d of dirs) await fs.rm(d, { recursive: true, force: true });
   for (const f of files) await fs.rm(f, { force: true });
 }
@@ -97,6 +100,13 @@ async function main() {
 
   log('copying apps/server/prisma.config.ts → apps/cli/prisma.config.ts');
   await copyFile(path.join(SERVER_DIR, 'prisma.config.ts'), path.join(CLI_DIR, 'prisma.config.ts'));
+
+  log('copying apps/server/scripts/monaco-editor.sh → apps/cli/scripts/monaco-editor.sh');
+  await copyFile(
+    path.join(SERVER_DIR, 'scripts/monaco-editor.sh'),
+    path.join(CLI_DIR, 'scripts/monaco-editor.sh')
+  );
+  await fs.chmod(path.join(CLI_DIR, 'scripts/monaco-editor.sh'), 0o755);
 
   log('copying apps/web/.next/standalone → apps/cli/.next/standalone');
   await copyDir(path.join(WEB_DIR, '.next/standalone'), path.join(CLI_DIR, '.next/standalone'));


### PR DESCRIPTION
## Summary
- `npm i -g` でグローバルインストールした環境で `monaco-editor.sh` がパッケージに同梱されず、Ctrl+G で Monaco Editor が開けない問題を修正
- `bundle.mjs` に `monaco-editor.sh` のコピー処理と実行権限付与を追加
- `package.json` の `files` に `scripts/monaco-editor.sh` を追加

## Test plan
- [x] グローバルインストール環境で Ctrl+G → Monaco Editor が正常に開くことを確認
- [ ] `npm run build` → `npm pack` で tarball 内に `scripts/monaco-editor.sh` が含まれることを確認
- [ ] dev 環境でも Monaco Editor が動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)