### PR TITLE
fix: task.order を non-nullable 化し自動採番を実装

### DIFF
--- a/apps/server/prisma/migrations/20260413000000_make_task_order_non_nullable/migration.sql
+++ b/apps/server/prisma/migrations/20260413000000_make_task_order_non_nullable/migration.sql
@@ -1,0 +1,47 @@
+-- BackfillNullOrders
+-- 既存の NULL order を createdAt 昇順で連番付与（既存の最大値の後ろから）
+WITH ranked AS (
+  SELECT id,
+         ROW_NUMBER() OVER (ORDER BY created_at ASC) AS rn
+  FROM tasks
+  WHERE "order" IS NULL AND deleted_at IS NULL
+)
+UPDATE tasks
+SET "order" = (
+  SELECT COALESCE(MAX("order"), -1) FROM tasks WHERE "order" IS NOT NULL AND deleted_at IS NULL
+) + (SELECT rn FROM ranked WHERE ranked.id = tasks.id)
+WHERE id IN (SELECT id FROM ranked);
+
+-- 論理削除済みタスクにも 0 を入れておく（NOT NULL 制約のため）
+UPDATE tasks SET "order" = 0 WHERE "order" IS NULL;
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_tasks" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "owner" TEXT NOT NULL,
+    "repo" TEXT NOT NULL,
+    "branch" TEXT NOT NULL,
+    "base_branch" TEXT NOT NULL,
+    "repo_id" TEXT NOT NULL,
+    "worktree_status" TEXT NOT NULL,
+    "pull_request_url" TEXT,
+    "effort" INTEGER,
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "deleted_at" DATETIME,
+    "created_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" DATETIME NOT NULL,
+    CONSTRAINT "tasks_repo_id_fkey" FOREIGN KEY ("repo_id") REFERENCES "repositories" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_tasks" ("id", "title", "description", "status", "owner", "repo", "branch", "base_branch", "repo_id", "worktree_status", "pull_request_url", "effort", "order", "deleted_at", "created_at", "updated_at") SELECT "id", "title", "description", "status", "owner", "repo", "branch", "base_branch", "repo_id", "worktree_status", "pull_request_url", "effort", "order", "deleted_at", "created_at", "updated_at" FROM "tasks";
+DROP TABLE "tasks";
+ALTER TABLE "new_tasks" RENAME TO "tasks";
+CREATE INDEX "tasks_owner_repo_idx" ON "tasks"("owner", "repo");
+CREATE INDEX "tasks_status_idx" ON "tasks"("status");
+CREATE INDEX "tasks_deleted_at_idx" ON "tasks"("deleted_at");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -39,7 +39,7 @@ model Task {
   pullRequestUrl String?   @map("pull_request_url")
 
   effort         Int?
-  order          Int?
+  order          Int     @default(0)
   deletedAt      DateTime? @map("deleted_at")
   createdAt      DateTime  @default(now()) @map("created_at")
   updatedAt      DateTime  @updatedAt @map("updated_at")

--- a/apps/server/src/lib/repositories/task.ts
+++ b/apps/server/src/lib/repositories/task.ts
@@ -1,6 +1,8 @@
 import { prisma } from '../db.js';
 import type { Task, Tab } from '@minimalcorp/tsunagi-shared';
 
+export type TxClient = Parameters<Parameters<(typeof prisma)['$transaction']>[0]>[0];
+
 // タスク一覧取得（deleted: false のみデフォルト）
 export async function getTasks(filter?: {
   includeDeleted?: boolean;
@@ -24,7 +26,7 @@ export async function getTasks(filter?: {
         orderBy: { order: 'asc' },
       },
     },
-    orderBy: { createdAt: 'desc' },
+    orderBy: [{ order: 'asc' }, { createdAt: 'asc' }],
   });
 
   return tasks.map((task) => mapTask(task));
@@ -48,9 +50,11 @@ export async function getTask(id: string): Promise<Task | null> {
 
 // タスク作成
 export async function createTask(
-  task: Omit<Task, 'id' | 'deleted' | 'deletedAt' | 'createdAt' | 'updatedAt' | 'tabs'>
+  task: Omit<Task, 'id' | 'deleted' | 'deletedAt' | 'createdAt' | 'updatedAt' | 'tabs'>,
+  tx?: TxClient
 ): Promise<Task> {
-  const newTask = await prisma.task.create({
+  const client = tx ?? prisma;
+  const newTask = await client.task.create({
     data: {
       status: task.status,
       title: task.title,
@@ -105,8 +109,13 @@ export async function updateTask(
 }
 
 // 指定order以上のタスクを+1ずらす（玉突き）
-export async function bumpOrder(targetOrder: number, excludeTaskId?: string): Promise<void> {
-  await prisma.task.updateMany({
+export async function bumpOrder(
+  targetOrder: number,
+  excludeTaskId?: string,
+  tx?: TxClient
+): Promise<void> {
+  const client = tx ?? prisma;
+  await client.task.updateMany({
     where: {
       order: { gte: targetOrder },
       deletedAt: null,
@@ -264,7 +273,7 @@ type PrismaTask = {
   worktreeStatus: string;
   pullRequestUrl: string | null;
   effort: number | null;
-  order: number | null;
+  order: number;
   deletedAt: Date | null;
   createdAt: Date;
   updatedAt: Date;
@@ -295,7 +304,7 @@ function mapTask(task: PrismaTask): Task {
     worktreeStatus: task.worktreeStatus as Task['worktreeStatus'],
     pullRequestUrl: task.pullRequestUrl ?? undefined,
     effort: task.effort ?? undefined,
-    order: task.order ?? undefined,
+    order: task.order,
     deletedAt: task.deletedAt?.toISOString(),
     createdAt: task.createdAt.toISOString(),
     updatedAt: task.updatedAt.toISOString(),

--- a/apps/server/src/lib/services/task-service.ts
+++ b/apps/server/src/lib/services/task-service.ts
@@ -194,24 +194,36 @@ export async function createTask(
     );
   }
 
-  // 1. order指定時は玉突き処理
-  if (order !== undefined) {
-    await taskRepo.bumpOrder(order);
-  }
+  // 1. order解決 + bumpOrder + DB登録をアトミックに実行
+  const newTask = await prisma.$transaction(async (tx) => {
+    let resolvedOrder: number;
+    if (order !== undefined) {
+      resolvedOrder = order;
+      await taskRepo.bumpOrder(resolvedOrder, undefined, tx);
+    } else {
+      const result = await tx.task.aggregate({
+        where: { owner, repo, deletedAt: null },
+        _max: { order: true },
+      });
+      resolvedOrder = (result._max.order ?? -1) + 1;
+    }
 
-  // 2. DBにタスク登録
-  const newTask = await taskRepo.createTask({
-    title,
-    description,
-    status,
-    owner,
-    repo,
-    branch,
-    baseBranch,
-    repoId: repository.id,
-    worktreeStatus: 'pending',
-    effort,
-    order,
+    return await taskRepo.createTask(
+      {
+        title,
+        description,
+        status,
+        owner,
+        repo,
+        branch,
+        baseBranch,
+        repoId: repository.id,
+        worktreeStatus: 'pending',
+        effort,
+        order: resolvedOrder,
+      },
+      tx
+    );
   });
 
   // 3. worktree作成

--- a/apps/web/docs/data-models.md
+++ b/apps/web/docs/data-models.md
@@ -192,10 +192,10 @@ interface Task {
 
 #### order
 
-- **型**: `number | undefined`
+- **型**: `number`（必須、タスク作成時に未指定なら自動採番）
 - **範囲**: 0以上の整数（0, 1, 2, 3, ...）
 - **意味**: 小さいほど優先度が高い（order 0 が最優先）
-- **生成**: Claudeがタスク内容・工数・緊急性を加味して自動判定
+- **生成**: 未指定時は同一リポジトリ内の MAX(order) + 1 を自動割り当て。Claudeが明示指定することも可能
 - **例**:
   - `0` - 最優先タスク
   - `1` - 2番目に優先
@@ -209,7 +209,7 @@ interface Task {
   - タスクの緊急性・重要性
   - 依存関係（将来実装）
   - 工数とのバランス
-- **ソート**: `tasks.sort((a, b) => (a.order ?? Infinity) - (b.order ?? Infinity))`
+- **ソート**: `tasks.sort((a, b) => a.order - b.order)`
 
 #### logs
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -109,7 +109,7 @@ export default function Home() {
           return false;
         return true;
       })
-      .sort((a, b) => (a.order ?? Infinity) - (b.order ?? Infinity));
+      .sort((a, b) => a.order - b.order);
   }, [tasks, filterState]);
 
   // 初回データロード

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -15,7 +15,7 @@ export interface Task {
   pullRequestUrl?: string;
 
   effort?: number;
-  order?: number;
+  order: number;
   deletedAt?: string;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
## Summary

- `task.order` を nullable (`Int?`) から required (`Int @default(0)`) に変更
- タスク作成時に `order` 未指定の場合、`MAX(order) + 1` を自動採番（リスト末尾に追加）
- 自動採番 + bumpOrder + DB登録を `prisma.$transaction` でアトミック化（複数Claudeの同時タスク作成時のレース対策）
- リポジトリ層の `createTask` / `bumpOrder` に `tx` 引数を追加（既存呼出元は影響なし）
- サーバー側 `orderBy` を `createdAt desc` から `order asc` に変更（フロントと整合）
- 既存の NULL order をマイグレーションで `createdAt` 昇順に連番バックフィル

## Test plan

- [ ] 既存タスクの並び順が壊れていないこと
- [ ] 新規タスク作成時に order が自動割り当てされ、リスト末尾に表示されること
- [ ] ドラッグ&ドロップによるリオーダーがリロード後も維持されること
- [ ] マイグレーション適用後に NULL order が残っていないこと
- [ ] `npm run lint` / `npm run type-check` 全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)