### PR TITLE
fix: docs検索結果を表示中の言語に限定する

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "next dev --port 2793",
     "build": "next build",
-    "postbuild": "pagefind --site out --output-subdir _pagefind",
+    "postbuild": "node scripts/fix-html-lang.js && pagefind --site out --output-subdir _pagefind",
     "start": "next start --port 2793",
     "lint": "eslint",
     "type-check": "tsc --noEmit"

--- a/apps/docs/scripts/fix-html-lang.js
+++ b/apps/docs/scripts/fix-html-lang.js
@@ -1,0 +1,49 @@
+import { readdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const OUT_DIR = new URL('../out', import.meta.url).pathname;
+
+// Default locale pages already have the correct lang="en" from root layout,
+// so only non-default locales need patching.
+const LOCALES = ['ja'];
+
+async function collectHtmlFiles(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await collectHtmlFiles(full)));
+    } else if (entry.name.endsWith('.html')) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+let totalFixed = 0;
+
+for (const locale of LOCALES) {
+  const localeDir = join(OUT_DIR, locale);
+  let files;
+  try {
+    files = await collectHtmlFiles(localeDir);
+  } catch {
+    console.log(`Skipping locale "${locale}" — directory not found`);
+    continue;
+  }
+
+  let count = 0;
+  for (const file of files) {
+    const html = await readFile(file, 'utf8');
+    const updated = html.replace('<html lang="en"', `<html lang="${locale}"`);
+    if (updated !== html) {
+      await writeFile(file, updated);
+      count++;
+    }
+  }
+  console.log(`[fix-html-lang] ${locale}: patched ${count}/${files.length} files`);
+  totalFixed += count;
+}
+
+console.log(`[fix-html-lang] Done — ${totalFixed} file(s) updated`);


### PR DESCRIPTION
## Summary

- `apps/docs/scripts/fix-html-lang.js` を追加: post-build で `out/ja/**/*.html` の `<html lang="en">` を `<html lang="ja">` に置換するスクリプト
- `apps/docs/package.json` の `postbuild` を更新: lang修正 → Pagefindインデックス作成の順序で実行

## Background

root layout の `<html lang="en">` がハードコードされているため、全ページが英語としてPagefindにインデックスされ、検索結果に全言語のページが混在していた。post-buildで静的HTMLのlang属性をパスに応じて修正することで、Pagefindのデフォルト言語フィルタが正しく機能するようになる。

## Test plan

- [ ] `npm run build` 実行後、`out/ja/index.html` の `<html lang="ja">` を確認
- [ ] `out/_pagefind/pagefind-entry.json` に `en` と `ja` 両方のインデックスが存在することを確認
- [ ] 英語版で検索 → 英語ページのみ表示されること
- [ ] 日本語版で検索 → 日本語ページのみ表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)