### PR TITLE
fix: docsトップページでブラウザ言語に応じてロケールを振り分ける

### DIFF
--- a/apps/docs/app/page.tsx
+++ b/apps/docs/app/page.tsx
@@ -1,23 +1,57 @@
-// `/` にアクセスされた場合、デフォルトロケール (英語) にリダイレクトする。
-// static export 環境ではランタイム redirect() が効かないため、
-// HTML meta refresh + クライアント側 JS fallback で対応する。
+// `/` にアクセスされた場合、ブラウザの言語設定に応じてロケール別のトップページに
+// リダイレクトする。static export 環境ではサーバーサイドで Accept-Language を読めないため、
+// クライアントサイド JS で navigator.languages を見て振り分ける。
 //
-// GitHub Pages で basePath がある場合に備えて、相対パス形式のリンクを
-// 使う (basePath は Next.js が自動で付与する)。
+// 優先順位:
+//   1. localStorage の `tsunagi-docs-locale` (ユーザーが明示的に選択した言語)
+//   2. navigator.languages のプライマリサブタグが対応ロケールにマッチしたもの
+//   3. デフォルトロケール (en) にフォールバック
+//
+// JS 無効環境向けフォールバックとして meta refresh で `/en/` に飛ばす。
+
+const LOCALES = ['en', 'ja'] as const;
+const DEFAULT_LOCALE = 'en';
+const STORAGE_KEY = 'tsunagi-docs-locale';
 
 export default function RootPage() {
+  const script = `(function () {
+  var locales = ${JSON.stringify(LOCALES)};
+  var defaultLocale = ${JSON.stringify(DEFAULT_LOCALE)};
+  var storageKey = ${JSON.stringify(STORAGE_KEY)};
+  var basePath = location.pathname.replace(/\\/?$/, '');
+
+  function go(locale) {
+    window.location.replace(basePath + '/' + locale + '/');
+  }
+
+  try {
+    var stored = localStorage.getItem(storageKey);
+    if (stored && locales.indexOf(stored) !== -1) {
+      go(stored);
+      return;
+    }
+  } catch (e) {}
+
+  var preferred = (navigator.languages && navigator.languages.length)
+    ? navigator.languages
+    : [navigator.language || ''];
+  for (var i = 0; i < preferred.length; i++) {
+    var primary = String(preferred[i]).toLowerCase().split('-')[0];
+    if (locales.indexOf(primary) !== -1) {
+      go(primary);
+      return;
+    }
+  }
+  go(defaultLocale);
+})();`;
+
   return (
     <>
+      {/* JS 無効環境向けフォールバック。JS が動けば script の方が先に実行される */}
       <meta httpEquiv="refresh" content="0; url=./en/" />
-      <script
-        dangerouslySetInnerHTML={{
-          __html:
-            "window.location.replace(window.location.pathname.replace(/\\/?$/, '') + '/en/');",
-        }}
-      />
+      <script dangerouslySetInnerHTML={{ __html: script }} />
       <p style={{ fontFamily: 'system-ui, sans-serif', padding: '2rem' }}>
-        Redirecting to <a href="./en/">English documentation</a>
-        ...
+        Redirecting… / リダイレクトしています…
       </p>
     </>
   );


### PR DESCRIPTION
## Summary

- docs サイト `/` が常に `/en/` にハードコード遷移していたのを、`navigator.languages` と `localStorage` を見てロケールを選ぶよう変更
- 日本語ブラウザは `/ja/`、英語ブラウザは `/en/` に振り分け
- 未対応言語（中国語等）は `/en/` にフォールバック
- JS無効環境向けの `<meta http-equiv="refresh">` フォールバックは維持

## ロケール選択の優先順位

1. `localStorage.tsunagi-docs-locale`（手動切り替えの記憶用、書き込み側は別タスクで対応予定）
2. `navigator.languages` のプライマリサブタグ照合（`ja-JP` → `ja`、`en-US` → `en`）
3. デフォルト `en`

## Test plan

- [x] Prettier / ESLint / `tsc --noEmit` 全て pass
- [x] `next dev` で `/` を取得し、HTML 内に新しい locale 検出スクリプトが含まれることを確認
- [x] 実機ブラウザの言語設定を `日本語優先` にして `/` → `/ja/` に遷移する
- [x] 実機ブラウザの言語設定を `英語優先` にして `/` → `/en/` に遷移する
- [ ] JS 無効で `/` → meta refresh で `/en/` に遷移する

🤖 Generated with [Claude Code](https://claude.com/claude-code)