### PR TITLE
chore(cli): remove unused concurrently/dotenv from runtime deps

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -62,8 +62,6 @@
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@prisma/adapter-libsql": "^7.3.0",
     "@prisma/client": "^7.3.0",
-    "concurrently": "^9.2.1",
-    "dotenv": "^17.2.3",
     "fastify": "^5.8.2",
     "node-pty": "^1.1.0",
     "prisma": "^7.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,8 +37,6 @@
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@prisma/adapter-libsql": "^7.3.0",
         "@prisma/client": "^7.3.0",
-        "concurrently": "^9.2.1",
-        "dotenv": "^17.2.3",
         "fastify": "^5.8.2",
         "node-pty": "^1.1.0",
         "prisma": "^7.3.0",
@@ -7038,6 +7036,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -7054,6 +7053,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -7069,6 +7069,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -7595,6 +7596,7 @@
       "version": "9.2.1",
       "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
       "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",
@@ -10729,6 +10731,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -16633,6 +16636,7 @@
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -17076,6 +17080,7 @@
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
       "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -17775,6 +17780,7 @@
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -17999,6 +18005,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
       "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "tree-kill": "cli.js"


### PR DESCRIPTION
## Summary

- `apps/cli/package.json.dependencies` から `concurrently` と `dotenv` を削除
- これにより `npm install -g @minimalcorp/tsunagi` 時に consumer の global `node_modules` へ install される package 数が **9 件減少**（`concurrently` + transitive 7 件 `chalk`/`rxjs`/`shell-quote`/`tree-kill`/`supports-color`/`has-flag`/`ansi-styles`、および `dotenv`）
- tarball 本体は不変（15 MB / 1470 files）

## 調査結果

### `concurrently`

- 参照箇所は `apps/cli/src/with-plugin.ts` のみ（`npx concurrently` を spawn）
- `with-plugin.ts` は monorepo 内 dev エントリ（`npm run dev -w @minimalcorp/tsunagi` から呼ばれる）
- published `bin` = `dist/cli.js` は Fastify/Next を `spawn(node, entry)` で直接起動しており `concurrently` を使わない
- 従って consumer install 対象から外して問題なし。monorepo dev フローは root `package.json.devDependencies.concurrently` の hoisting で引き続き動作

### `dotenv`

- `apps/cli/src`, `apps/server/src`, `packages/shared` のいずれからも `from 'dotenv'` / `require('dotenv')` が見つからず、孤児依存

### 重複確認の副産物

- tarball 内 `.next/standalone/node_modules/*`（`next`/`react`/`react-dom`/`styled-jsx`/`@swc/helpers`/`@next/env`/`@img/*`/`sharp`/`detect-libc`/`client-only`）と `apps/cli/dependencies` の積集合 = **∅**
- すなわち「Next 専用依存が `dependencies` に残って standalone と二重化」という当初懸念は monorepo 分割 + `output: 'standalone'` 構成により既に解決済みだった

## Test plan

- [x] `npm run lint -w @minimalcorp/tsunagi`
- [x] `npm run type-check -w @minimalcorp/tsunagi`
- [x] `prettier --check apps/cli/package.json`
- [x] `npm pack --dry-run` で tarball サイズ / ファイル数が変化しないこと（15 MB / 1470 files）
- [x] `package-lock.json` で `concurrently` の transitive deps が `"dev": true` に格下げされ consumer install 対象外になること
- [x] apps/cli 文脈から `which concurrently` が root hoisted `node_modules/.bin/concurrently` を返すこと
- [ ] clean Docker 環境で `npm install -g ./minimalcorp-tsunagi-<ver>.tgz` → `tsunagi` 起動確認（release PR 側で smoke test 済みであれば省略可）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
