### PR TITLE
fix(cli): restore dotenv as runtime dependency

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -58,6 +58,7 @@
   },
   "dependencies": {
     "@fastify/cors": "^11.2.0",
+    "dotenv": "^17.2.3",
     "@libsql/client": "0.8.1",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@prisma/adapter-libsql": "^7.3.0",


### PR DESCRIPTION
## Summary

- `apps/cli/package.json` の `dependencies` に `dotenv` を再追加
- bundle時に `apps/server/prisma.config.ts` → `apps/cli/prisma.config.ts` へコピーされるが、このファイルが `import 'dotenv/config'` を使用するため、published packageに dotenv が必要
- #154 で誤って削除されたため、production環境で prisma migrate 実行時にクラッシュしていた