### PR TITLE
feat: タスク詳細画面の…メニューに Open Terminal / Open VS Code を追加

### DIFF
--- a/apps/web/src/app/tasks/[id]/page.tsx
+++ b/apps/web/src/app/tasks/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { use, useState, useEffect, useRef, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
-import { ArrowLeft, Ellipsis, Pencil, Trash2 } from 'lucide-react';
+import { ArrowLeft, Code2, Ellipsis, Pencil, Terminal, Trash2 } from 'lucide-react';
 import { apiUrl } from '@/lib/api-url';
 import type { Task, Tab } from '@minimalcorp/tsunagi-shared';
 import { TaskDialog } from '@/components/TaskDialog';
@@ -188,6 +188,52 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
     }
   };
 
+  // Terminal を開く
+  const handleOpenTerminal = async () => {
+    if (!task) return;
+    const notificationId = toast.loading('Opening terminal...', task.worktreePath);
+    try {
+      const res = await fetch(apiUrl('/api/commands/open'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          commandType: 'terminal',
+          owner: task.owner,
+          repo: task.repo,
+          branch: task.branch,
+        }),
+      });
+      if (!res.ok) throw new Error('Command execution failed');
+      toast.success(notificationId, 'Successfully opened terminal', task.worktreePath);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      toast.error(notificationId, 'Failed to open terminal', message);
+    }
+  };
+
+  // VS Code を開く
+  const handleOpenVSCode = async () => {
+    if (!task) return;
+    const notificationId = toast.loading('Opening VS Code...', task.worktreePath);
+    try {
+      const res = await fetch(apiUrl('/api/commands/open'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          commandType: 'vscode',
+          owner: task.owner,
+          repo: task.repo,
+          branch: task.branch,
+        }),
+      });
+      if (!res.ok) throw new Error('Command execution failed');
+      toast.success(notificationId, 'Successfully opened VS Code', task.worktreePath);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      toast.error(notificationId, 'Failed to open VS Code', message);
+    }
+  };
+
   // タスク削除
   const handleTaskDelete = () => {
     if (!task) return;
@@ -260,6 +306,15 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
               <DropdownMenuItem onClick={() => setIsEditDialogOpen(true)}>
                 <Pencil className="w-4 h-4" />
                 Detail / Edit
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={handleOpenTerminal}>
+                <Terminal className="w-4 h-4" />
+                Open Terminal
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={handleOpenVSCode}>
+                <Code2 className="w-4 h-4" />
+                Open VS Code
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem


### PR DESCRIPTION
## Summary

- タスク詳細画面（`/tasks/[id]`）右上の `...` メニューに `Open Terminal` と `Open VS Code` を追加
- クリックすると当該タスクの worktree パスを macOS Terminal / VS Code で開く
- 既存の `Detail / Edit` / `Delete` の挙動は変更なし

## Changes

`apps/web/src/app/tasks/[id]/page.tsx` のみ変更。

- `Code2`, `Terminal` アイコンを lucide-react から追加
- `handleOpenTerminal` / `handleOpenVSCode` ハンドラを追加（`POST /api/commands/open` を使用）
- DropdownMenuContent のメニュー構成を更新:

```
Detail / Edit
---
Open Terminal   ← 追加
Open VS Code    ← 追加
---
Delete
```

## Test plan

- [x] 任意のタスク詳細画面で `...` メニューを開き、`Open Terminal` / `Open VS Code` が表示されること
- [ ] `Open Terminal` クリック → worktree パスで macOS Terminal が開くこと
- [ ] `Open VS Code` クリック → worktree パスで VS Code が開くこと
- [ ] 成功時に Toast（success）、失敗時に Toast（error）が表示されること
- [ ] 既存の `Detail / Edit` と `Delete` が変わらず動くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)