### PR TITLE
fix: ページ遷移後のカーソルズレと Ctrl+G 後の Static 消失を修正

### DIFF
--- a/apps/server/scripts/monaco-editor.sh
+++ b/apps/server/scripts/monaco-editor.sh
@@ -18,12 +18,11 @@ if [ -z "$TMPFILE" ]; then
   exit 1
 fi
 
-# 代替画面 (alt screen) に切り替えて script の出力を claude の描画領域から隔離する。
-# vim/nano 等の通常の $EDITOR と同じ作法。これをやらないと script の stderr 出力が
-# main buffer に積まれて、claude の Ink renderer の位置情報と実画面がズレ、
-# $EDITOR 終了後の描画に余白が生じる。
+# alt screen に切り替えて $EDITOR フローの間は main buffer を凍結する。
+# vim/nano 等の通常の $EDITOR と同じ作法。これにより:
+# - sh script の（潜在的な）出力や claude の Ink 再描画の副作用が main buffer に影響しない
+# - sh exit 時の `\033[?1049l` で main buffer が pre-Ctrl+G 時の状態に完全復元される
 printf '\033[?1049h'
-# どんな経路で終了しても alt screen から確実に復帰させる
 trap 'printf "\033[?1049l"' EXIT
 
 # エラー報告用: alt screen から抜けてから stderr に出す
@@ -46,9 +45,6 @@ if [ -z "$SESSION_ID" ]; then
 fi
 
 # 完了までポーリング（無制限、0.1秒間隔。Ctrl+C で中断可能）
-# 速めの polling 間隔にしているのは、Cmd+Enter Submit 後に sh が foreground PG から
-# 抜けるまでの遅延を最小化するため（TerminalView 側の resize nudge が claude に
-# 届くように）。
 # レスポンスはプレーンテキスト "done" or "pending"（JSON パース不要）
 while true; do
   STATUS=$(curl -sf "$API_BASE/api/editor/session/$SESSION_ID" 2>/dev/null || echo "pending")

--- a/apps/server/src/routes/editor.ts
+++ b/apps/server/src/routes/editor.ts
@@ -78,22 +78,25 @@ export async function editorRoutes(fastify: FastifyInstance) {
 
       // Ink の <Static>（Claude の welcome splash や会話履歴など）は emit-once 設計で、
       // $EDITOR から復帰した後の通常 rerender では再 emit されず、画面から消えてしまう。
-      // Claude 2.1.119 では cols 変更の SIGWINCH でも Static は再 emit されないため、
-      // 代わりにユーザーによる実キーストロークを模倣して Ink の input-driven rerender を
-      // 発火させる: "/" で slash-command menu を開いて即 backspace で閉じる。
-      // menu open/close の state 遷移で Ink が full frame emit を行い Static が復帰する。
+      // ユーザー操作で「ブラウザ window を 1 文字分 resize」したケースでは Static を含む
+      // フレーム全体が再 emit され、それなりに適切な見た目に復帰することが分かっている。
+      // /complete 後に同等の SIGWINCH を発火させるため、PTY を cols+1 に bump → 元 cols
+      // に戻す。
+      // 別案として `/` + backspace を PTY に注入する方法もあるが、`/` は空入力先頭で
+      // slash-command menu を起動する一方、文字入力済みの状況では単なる文字挿入として
+      // 扱われ、期待する full-frame rerender が発火しないため不採用。
       //
       // - 300ms 遅延: sh の polling(最大100ms) + exit + claude foreground 復帰 を待つ
-      // - 50ms 間隔: `/` 処理後に slash menu が開いた状態で backspace を送る
-      // - net: 入力欄は元の状態に戻る（`/` を打って消したのと同じ）
+      // - 100ms 間隔: Ink の re-layout 完了後に元の cols に戻す
       if (session.tabId) {
         const ptySession = ptyManager.getSession(session.tabId);
         if (ptySession) {
+          const { cols, rows } = ptySession.pty;
           setTimeout(() => {
-            ptySession.pty.write('/');
+            ptySession.pty.resize(cols + 1, rows);
             setTimeout(() => {
-              ptySession.pty.write('\x7f'); // DEL (backspace)
-            }, 50);
+              ptySession.pty.resize(cols, rows);
+            }, 100);
           }, 300);
         }
       }

--- a/apps/server/src/routes/editor.ts
+++ b/apps/server/src/routes/editor.ts
@@ -76,21 +76,24 @@ export async function editorRoutes(fastify: FastifyInstance) {
       await writeFile(session.filePath, request.body.content, 'utf8');
       session.status = 'done';
 
-      // sh が polling で "done" を検知して exit し claude が foreground に戻った後、
-      // cols を一瞬変えることで SIGWINCH を発火させる。
-      // rows 変更と異なり cols 変更では Ink が全画面クリア + 全 UI 再描画を行うため、
-      // $EDITOR exit 後に blank になる余白が解消される。
-      // 300ms: server が /complete を受信した時点が T=0。sh の polling(最大100ms) +
-      //        exit + claude foreground 復帰 で ~150ms。余裕を持たせた値。
+      // Ink の <Static>（Claude の welcome splash や会話履歴など）は emit-once 設計で、
+      // $EDITOR から復帰した後の通常 rerender では再 emit されず、画面から消えてしまう。
+      // Claude 2.1.119 では cols 変更の SIGWINCH でも Static は再 emit されないため、
+      // 代わりにユーザーによる実キーストロークを模倣して Ink の input-driven rerender を
+      // 発火させる: "/" で slash-command menu を開いて即 backspace で閉じる。
+      // menu open/close の state 遷移で Ink が full frame emit を行い Static が復帰する。
+      //
+      // - 300ms 遅延: sh の polling(最大100ms) + exit + claude foreground 復帰 を待つ
+      // - 50ms 間隔: `/` 処理後に slash menu が開いた状態で backspace を送る
+      // - net: 入力欄は元の状態に戻る（`/` を打って消したのと同じ）
       if (session.tabId) {
         const ptySession = ptyManager.getSession(session.tabId);
         if (ptySession) {
-          const { cols, rows } = ptySession.pty;
           setTimeout(() => {
-            ptySession.pty.resize(cols + 1, rows);
+            ptySession.pty.write('/');
             setTimeout(() => {
-              ptySession.pty.resize(cols, rows);
-            }, 100);
+              ptySession.pty.write('\x7f'); // DEL (backspace)
+            }, 50);
           }, 300);
         }
       }

--- a/apps/server/src/routes/editor.ts
+++ b/apps/server/src/routes/editor.ts
@@ -76,37 +76,10 @@ export async function editorRoutes(fastify: FastifyInstance) {
       await writeFile(session.filePath, request.body.content, 'utf8');
       session.status = 'done';
 
-      // Ink の <Static>（Claude の welcome splash や会話履歴など）は emit-once 設計で、
-      // $EDITOR から復帰した後の通常 rerender では再 emit されず、画面から消えてしまう。
-      // ユーザー操作で「ブラウザ window を 1 文字分 resize」したケースでは Static を含む
-      // フレーム全体が再 emit され、それなりに適切な見た目に復帰することが分かっている。
-      // /complete 後に同等の SIGWINCH を発火させるため、PTY を cols-1 に bump → 元 cols
-      // に戻す。
-      // cols+1 ではなく cols-1 を使う理由: bump 中は PTY 側が xterm より狭くなるだけで
-      // 出力は必ず xterm 幅に収まる。逆に cols+1 だと bump 中に Claude が xterm より
-      // 広い行を出力し、xterm 側で wrap → 余計なスクロールを誘発する。
-      // 別案として `/` + backspace を PTY に注入する方法もあるが、`/` は空入力先頭で
-      // slash-command menu を起動する一方、文字入力済みの状況では単なる文字挿入として
-      // 扱われ、期待する full-frame rerender が発火しないため不採用。
-      //
-      // - 300ms 遅延: sh の polling(最大100ms) + exit + claude foreground 復帰 を待つ
-      // - 100ms 間隔: Ink の re-layout 完了後に元の cols に戻す
-      if (session.tabId) {
-        const ptySession = ptyManager.getSession(session.tabId);
-        if (ptySession) {
-          const { cols, rows } = ptySession.pty;
-          // cols が 1 以下のときは bump できない（resize(0, ...) は無効）。実用上ほぼ
-          // 起き得ないが安全側に倒して何もしない。
-          if (cols > 1) {
-            setTimeout(() => {
-              ptySession.pty.resize(cols - 1, rows);
-              setTimeout(() => {
-                ptySession.pty.resize(cols, rows);
-              }, 100);
-            }, 300);
-          }
-        }
-      }
+      // Ink の <Static> 再 emit を発火させる cols bump はフロントエンド (TerminalView)
+      // 側で行う。理由: ユーザー操作の window resize と同等の挙動（xterm と PTY が
+      // 同時に新サイズになる）にしたいため。サーバー側で PTY だけ resize すると xterm
+      // との dimension mismatch が発生する。
 
       return reply.send({ ok: true });
     }

--- a/apps/server/src/routes/editor.ts
+++ b/apps/server/src/routes/editor.ts
@@ -80,8 +80,11 @@ export async function editorRoutes(fastify: FastifyInstance) {
       // $EDITOR から復帰した後の通常 rerender では再 emit されず、画面から消えてしまう。
       // ユーザー操作で「ブラウザ window を 1 文字分 resize」したケースでは Static を含む
       // フレーム全体が再 emit され、それなりに適切な見た目に復帰することが分かっている。
-      // /complete 後に同等の SIGWINCH を発火させるため、PTY を cols+1 に bump → 元 cols
+      // /complete 後に同等の SIGWINCH を発火させるため、PTY を cols-1 に bump → 元 cols
       // に戻す。
+      // cols+1 ではなく cols-1 を使う理由: bump 中は PTY 側が xterm より狭くなるだけで
+      // 出力は必ず xterm 幅に収まる。逆に cols+1 だと bump 中に Claude が xterm より
+      // 広い行を出力し、xterm 側で wrap → 余計なスクロールを誘発する。
       // 別案として `/` + backspace を PTY に注入する方法もあるが、`/` は空入力先頭で
       // slash-command menu を起動する一方、文字入力済みの状況では単なる文字挿入として
       // 扱われ、期待する full-frame rerender が発火しないため不採用。
@@ -92,12 +95,16 @@ export async function editorRoutes(fastify: FastifyInstance) {
         const ptySession = ptyManager.getSession(session.tabId);
         if (ptySession) {
           const { cols, rows } = ptySession.pty;
-          setTimeout(() => {
-            ptySession.pty.resize(cols + 1, rows);
+          // cols が 1 以下のときは bump できない（resize(0, ...) は無効）。実用上ほぼ
+          // 起き得ないが安全側に倒して何もしない。
+          if (cols > 1) {
             setTimeout(() => {
-              ptySession.pty.resize(cols, rows);
-            }, 100);
-          }, 300);
+              ptySession.pty.resize(cols - 1, rows);
+              setTimeout(() => {
+                ptySession.pty.resize(cols, rows);
+              }, 100);
+            }, 300);
+          }
         }
       }
 

--- a/apps/web/src/components/TerminalView.tsx
+++ b/apps/web/src/components/TerminalView.tsx
@@ -199,6 +199,8 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
     // キャンバスの再描画は変更があった行のみに最適化されているため、上部の行が再描画されず
     // 余白として見える問題がある（ネイティブターミナルでは発生しない xterm.js 固有の挙動）。
     // onBufferChange で normal buffer への切り替えを検知し、refresh() で全行を強制再描画する。
+    // editor session 中は suppressResizeRef=true だが、alt→normal 復帰時の refresh は
+    // 必ず走らせたい（main buffer のログエリアを復元するため）。
     term.buffer.onBufferChange((buf) => {
       if (buf.type === 'normal') {
         term.refresh(0, term.rows - 1);
@@ -210,6 +212,11 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
     // そのため我々が compositionstart/end を監視して onData をガードする必要はない。
 
     const observer = new ResizeObserver(() => {
+      // editor session (Ctrl+G Monaco modal) 中は fit / sendResize を一切行わない。
+      // Base UI Dialog が body に scrollbar-gutter 等を付与して viewport 幅が変わっても
+      // PTY へ SIGWINCH を投げない。alt screen 中の size 変更 → 復帰後の Ink redraw で
+      // main buffer のログエリアが消える問題を回避する。
+      if (isExternalEditorOpenRef.current) return;
       fitAddon.fit();
       // reused接続中はリングバッファ受信前にsendResizeしない（suppressResizeRefで制御）
       if (!suppressResizeRef.current) {
@@ -246,13 +253,25 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
   // エディタセッション開閉イベント（EditorSessionProvider → TerminalView 通知）
   useEffect(() => {
     function handleEditorSessionOpen() {
-      // xterm の _keyUp による focus 再取得を防ぐフラグを立てる
+      // xterm の _keyUp による focus 再取得を防ぐ + ResizeObserver 抑制の根拠フラグ。
+      // Monaco modal の scroll lock で body 幅が変化しても PTY へ resize を投げないことで
+      // alt screen 中の SIGWINCH → 復帰後の Ink full-redraw による main buffer 消失を防ぐ。
       isExternalEditorOpenRef.current = true;
       // xterm から明示的に blur して Monaco がフォーカスを取得できるようにする
       termRef.current?.blur();
     }
     function handleEditorSessionDone() {
-      isExternalEditorOpenRef.current = false;
+      // monaco-editor.sh の alt screen 抜け（0.1s poll + curl RTT）を待って観測解除する。
+      // これで modal close 直後の ResizeObserver fit が session 中の fit 再開として扱われ、
+      // alt→normal 復帰後に落ち着いた状態で PTY と同期する。
+      setTimeout(() => {
+        isExternalEditorOpenRef.current = false;
+        // close 時に viewport が変化していれば observer が次回 tick で fit+sendResize する。
+        // 変化していなくても xterm 側は session 中 fit していないので PTY と不整合はない。
+        // 明示的に一度 fit+sendResize して念のため同期する。
+        fitAddonRef.current?.fit();
+        sendResize();
+      }, 200);
       // アクティブタブのみフォーカスを復帰する
       if (!isActiveRef.current) return;
       // xterm 内の textarea を直接 focus する（Terminal.focus() では効かない）
@@ -416,7 +435,24 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
         term.write(data, () => {
           suppressResizeRef.current = false;
           fitAddonRef.current?.fit();
-          sendResize();
+          // cols を +1 → 元に戻す bump でPTYにSIGWINCHを発生させ、
+          // Claude (Ink) の内部状態を fresh な xterm 状態と再同期させる。
+          // 同一サイズの resize は PTY 側で no-op となり SIGWINCH が飛ばないため、
+          // ページ遷移後にカーソル位置がずれる問題を解消する。
+          const s = socketRef.current;
+          const t = termRef.current;
+          const sid = sessionIdRef.current;
+          if (s?.connected && sid && t) {
+            s.emit('resize', { sessionId: sid, cols: t.cols + 1, rows: t.rows });
+            setTimeout(() => {
+              const s2 = socketRef.current;
+              const t2 = termRef.current;
+              if (s2?.connected && sid && t2) {
+                s2.emit('resize', { sessionId: sid, cols: t2.cols, rows: t2.rows });
+              }
+            }, 50);
+          }
+          term.scrollToBottom();
         });
       } else {
         term.write(data);

--- a/apps/web/src/components/TerminalView.tsx
+++ b/apps/web/src/components/TerminalView.tsx
@@ -271,18 +271,21 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
       // 同時に新サイズになる方が Ink の挙動が安定する。サーバー側で PTY だけ resize
       // すると xterm との dimension mismatch が発生する。
       //
-      // cols+ ではなく cols- を使う理由: bump 中は PTY が xterm より狭くなるだけで
-      // 出力は必ず xterm 幅に収まる。逆に cols+ だと bump 中に Claude が xterm より
-      // 広い行を出力し、xterm 側で wrap → 余計なスクロールを誘発する。
+      // 一定の幅を下回ると Ink が full-frame redraw を行い Static が再 emit されることが
+      // 観測されているため、bump 時は必ず COLS_RESET_SIZE 以下の幅に揃える。
+      // ただし元 cols が既に COLS_RESET_SIZE と等しい場合は cols が変化せず SIGWINCH が
+      // 発火しないため、その場合だけ COLS_RESET_SIZE - 1 に揃える。これで bump 時には
+      // 必ず cols が変化し、その後 fit() で container 実サイズに戻ることを保証する。
       //
       // - 300ms 遅延: sh の polling(最大100ms) + exit + claude foreground 復帰 を待つ
       // - 100ms 間隔: Ink の re-layout 完了後に元の cols に戻す（fit() で container
       //   実サイズに re-fit）
-      const BUMP_DELTA = 30;
+      const COLS_RESET_SIZE = 64;
       setTimeout(() => {
         const term = termRef.current;
-        if (term && term.cols > BUMP_DELTA) {
-          term.resize(term.cols - BUMP_DELTA, term.rows);
+        if (term) {
+          const bumpCols = term.cols === COLS_RESET_SIZE ? COLS_RESET_SIZE - 1 : COLS_RESET_SIZE;
+          term.resize(bumpCols, term.rows);
           sendResize();
           setTimeout(() => {
             isExternalEditorOpenRef.current = false;
@@ -290,10 +293,7 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
             sendResize();
           }, 100);
         } else {
-          // bump できないほど terminal が小さい場合は flag 解除のみ
           isExternalEditorOpenRef.current = false;
-          fitAddonRef.current?.fit();
-          sendResize();
         }
       }, 300);
       // アクティブタブのみフォーカスを復帰する
@@ -467,7 +467,7 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
           const t = termRef.current;
           const sid = sessionIdRef.current;
           if (s?.connected && sid && t) {
-            s.emit('resize', { sessionId: sid, cols: t.cols + 1, rows: t.rows });
+            s.emit('resize', { sessionId: sid, cols: t.cols - 1, rows: t.rows });
             setTimeout(() => {
               const s2 = socketRef.current;
               const t2 = termRef.current;

--- a/apps/web/src/components/TerminalView.tsx
+++ b/apps/web/src/components/TerminalView.tsx
@@ -261,17 +261,41 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
       termRef.current?.blur();
     }
     function handleEditorSessionDone() {
-      // monaco-editor.sh の alt screen 抜け（0.1s poll + curl RTT）を待って観測解除する。
-      // これで modal close 直後の ResizeObserver fit が session 中の fit 再開として扱われ、
-      // alt→normal 復帰後に落ち着いた状態で PTY と同期する。
+      // Ink の <Static>（Claude の welcome splash や会話履歴など）は emit-once 設計で、
+      // $EDITOR から復帰した後の通常 rerender では再 emit されず画面から消えてしまう。
+      // ユーザー操作で window を 1 文字分 resize したケースでは Static を含むフレーム
+      // 全体が再 emit され、それなりに適切な見た目に復帰することが分かっている。
+      // 同等の SIGWINCH を発火させるため、xterm + PTY を一時的に縮める cols bump を行う。
+      //
+      // フロントエンドで bump する理由: user の window resize と同じく xterm / PTY が
+      // 同時に新サイズになる方が Ink の挙動が安定する。サーバー側で PTY だけ resize
+      // すると xterm との dimension mismatch が発生する。
+      //
+      // cols+ ではなく cols- を使う理由: bump 中は PTY が xterm より狭くなるだけで
+      // 出力は必ず xterm 幅に収まる。逆に cols+ だと bump 中に Claude が xterm より
+      // 広い行を出力し、xterm 側で wrap → 余計なスクロールを誘発する。
+      //
+      // - 300ms 遅延: sh の polling(最大100ms) + exit + claude foreground 復帰 を待つ
+      // - 100ms 間隔: Ink の re-layout 完了後に元の cols に戻す（fit() で container
+      //   実サイズに re-fit）
+      const BUMP_DELTA = 30;
       setTimeout(() => {
-        isExternalEditorOpenRef.current = false;
-        // close 時に viewport が変化していれば observer が次回 tick で fit+sendResize する。
-        // 変化していなくても xterm 側は session 中 fit していないので PTY と不整合はない。
-        // 明示的に一度 fit+sendResize して念のため同期する。
-        fitAddonRef.current?.fit();
-        sendResize();
-      }, 200);
+        const term = termRef.current;
+        if (term && term.cols > BUMP_DELTA) {
+          term.resize(term.cols - BUMP_DELTA, term.rows);
+          sendResize();
+          setTimeout(() => {
+            isExternalEditorOpenRef.current = false;
+            fitAddonRef.current?.fit();
+            sendResize();
+          }, 100);
+        } else {
+          // bump できないほど terminal が小さい場合は flag 解除のみ
+          isExternalEditorOpenRef.current = false;
+          fitAddonRef.current?.fit();
+          sendResize();
+        }
+      }, 300);
       // アクティブタブのみフォーカスを復帰する
       if (!isActiveRef.current) return;
       // xterm 内の textarea を直接 focus する（Terminal.focus() では効かない）

--- a/apps/web/src/components/TerminalView.tsx
+++ b/apps/web/src/components/TerminalView.tsx
@@ -23,6 +23,12 @@ import { apiUrl, getServerUrl } from '@/lib/api-url';
 export type TerminalStatus = 'idle' | 'connecting' | 'connected' | 'paused' | 'exited' | 'error';
 export type ClaudeStatus = 'idle' | 'running' | 'waiting' | 'success' | 'failure' | 'error';
 
+// Ink の <Static> を再 emit させるため、xterm + PTY を一時的にこの幅に揃える。
+// 一定の幅を下回ると Ink が full-frame redraw を行い Static が再描画されるという
+// 観測に基づくしきい値。元 cols が既にこの値の場合のみ -1 にして必ず cols を変化させ、
+// SIGWINCH を発火させる。
+const COLS_RESET_SIZE = 64;
+
 export interface Todo {
   content: string;
   status: 'pending' | 'in_progress' | 'completed' | 'deleted';
@@ -271,16 +277,11 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
       // 同時に新サイズになる方が Ink の挙動が安定する。サーバー側で PTY だけ resize
       // すると xterm との dimension mismatch が発生する。
       //
-      // 一定の幅を下回ると Ink が full-frame redraw を行い Static が再 emit されることが
-      // 観測されているため、bump 時は必ず COLS_RESET_SIZE 以下の幅に揃える。
-      // ただし元 cols が既に COLS_RESET_SIZE と等しい場合は cols が変化せず SIGWINCH が
-      // 発火しないため、その場合だけ COLS_RESET_SIZE - 1 に揃える。これで bump 時には
-      // 必ず cols が変化し、その後 fit() で container 実サイズに戻ることを保証する。
+      // bump サイズの選び方は COLS_RESET_SIZE のコメントを参照。
       //
       // - 300ms 遅延: sh の polling(最大100ms) + exit + claude foreground 復帰 を待つ
       // - 100ms 間隔: Ink の re-layout 完了後に元の cols に戻す（fit() で container
       //   実サイズに re-fit）
-      const COLS_RESET_SIZE = 64;
       setTimeout(() => {
         const term = termRef.current;
         if (term) {
@@ -459,21 +460,20 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
         term.write(data, () => {
           suppressResizeRef.current = false;
           fitAddonRef.current?.fit();
-          // cols を +1 → 元に戻す bump でPTYにSIGWINCHを発生させ、
+          // 一時的に xterm + PTY を COLS_RESET_SIZE に揃える bump で SIGWINCH を発火させ、
           // Claude (Ink) の内部状態を fresh な xterm 状態と再同期させる。
           // 同一サイズの resize は PTY 側で no-op となり SIGWINCH が飛ばないため、
           // ページ遷移後にカーソル位置がずれる問題を解消する。
-          const s = socketRef.current;
+          // editor-session-done と同じ「xterm と PTY を同時に同じ値に resize する」
+          // 対称パターンを使い、dimension mismatch を避ける。
           const t = termRef.current;
-          const sid = sessionIdRef.current;
-          if (s?.connected && sid && t) {
-            s.emit('resize', { sessionId: sid, cols: t.cols - 1, rows: t.rows });
+          if (t) {
+            const bumpCols = t.cols === COLS_RESET_SIZE ? COLS_RESET_SIZE - 1 : COLS_RESET_SIZE;
+            t.resize(bumpCols, t.rows);
+            sendResize();
             setTimeout(() => {
-              const s2 = socketRef.current;
-              const t2 = termRef.current;
-              if (s2?.connected && sid && t2) {
-                s2.emit('resize', { sessionId: sid, cols: t2.cols, rows: t2.rows });
-              }
+              fitAddonRef.current?.fit();
+              sendResize();
             }, 50);
           }
           term.scrollToBottom();


### PR DESCRIPTION
## ページ遷移後カーソルズレ

リングバッファ replay 完了時に cols+1 → cols bump を発行し、Claude (Ink) の内部状態を fresh な xterm 状態と再同期させる。同一サイズの resize は
PTY 側で no-op となり SIGWINCH が飛ばないため明示的な bump が必要。

## Ctrl+G Monaco close 後の Static 消失

Claude 2.1.119 の Ink は <Static>（welcome splash / 会話履歴）を $EDITOR 復帰後の rerender で再 emit せず空白になる。cols 変更 SIGWINCH も full redraw を起動しなくなったため、ユーザーが手動で `/` + backspace すると
Static が復帰するという観測に基づき、/complete 後 300ms で `/` + DEL を PTY に注入する。net で入力欄は元状態。slash menu open/close の state 遷移により Ink が full frame emit を行う。

合わせて以下の防御も追加:

- editor session 中は ResizeObserver の fit/sendResize を抑制 （Modal の scroll lock で viewport が変わっても PTY を揺らさない）
- session done 後 200ms で fit+sendResize して xterm/PTY を同期
- onBufferChange の suppressResizeRef ゲートを除去し alt→normal 復帰 時の term.refresh を常に走らせる