### PR TITLE
feat: Fastify を単一入口に集約し cloudflared 公開対応 + Basic 認証

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,6 +4,8 @@ node_modules
 # Next.js
 .next
 out
+# Next が dev 実行時に独自フォーマットで自動書き換えするため prettier 対象外にする
+apps/web/tsconfig.json
 
 # Build
 build

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -59,6 +59,7 @@
   },
   "dependencies": {
     "@fastify/cors": "^11.2.0",
+    "@fastify/http-proxy": "^11.5.0",
     "dotenv": "^17.2.3",
     "@libsql/client": "0.8.1",
     "@modelcontextprotocol/sdk": "^1.27.1",

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -206,18 +206,20 @@ function verifyArtifact(p: string, label: string): void {
 verifyArtifact(FASTIFY_ENTRY_JS, 'Fastify server artifact');
 verifyArtifact(NEXT_STANDALONE_ENTRY, 'Next.js standalone artifact');
 
+// Fastify が単一の公開ポート。Next.js は内部ポートで動かし Fastify からプロキシする。
 const PORT = process.env.PORT ?? '2791';
+const NEXT_PORT = '2792';
 
 const fastifyChild: ChildProcess = spawn(process.execPath, [FASTIFY_ENTRY_JS], {
   stdio: ['inherit', 'pipe', 'pipe'],
   cwd: PACKAGE_ROOT,
-  env: { ...process.env, NODE_ENV: 'production' },
+  env: { ...process.env, NODE_ENV: 'production', PORT, TSUNAGI_NEXT_PORT: NEXT_PORT },
 });
 
 const nextChild: ChildProcess = spawn(process.execPath, [NEXT_STANDALONE_ENTRY], {
   stdio: ['inherit', 'pipe', 'pipe'],
   cwd: path.dirname(NEXT_STANDALONE_ENTRY),
-  env: { ...process.env, PORT, NODE_ENV: 'production', HOSTNAME: '0.0.0.0' },
+  env: { ...process.env, PORT: NEXT_PORT, NODE_ENV: 'production', HOSTNAME: '0.0.0.0' },
 });
 
 const docsServer = startDocsServer();
@@ -241,7 +243,6 @@ nextChild.stderr?.on('data', (data: Buffer) => {
 // ---------------------------------------------------------------------------
 // Ready detection via /health polling
 // ---------------------------------------------------------------------------
-const SERVER_PORT = 2792;
 const POLL_INTERVAL_MS = 300;
 
 function pollHealth(port: number): Promise<void> {
@@ -264,7 +265,8 @@ function pollHealth(port: number): Promise<void> {
   });
 }
 
-Promise.all([pollHealth(SERVER_PORT), pollHealth(Number(PORT))]).then(() => {
+// Fastify(PORT) と Next(NEXT_PORT) は各々 /health を持つ。各プロセスを直接叩く。
+Promise.all([pollHealth(Number(PORT)), pollHealth(Number(NEXT_PORT))]).then(() => {
   spinner.stop();
   console.log(TSUNAGI_AA);
 

--- a/apps/cli/tsunagi-marketplace/plugins/tsunagi-plugin/.claude-plugin/plugin.json
+++ b/apps/cli/tsunagi-marketplace/plugins/tsunagi-plugin/.claude-plugin/plugin.json
@@ -8,7 +8,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "curl -s -X POST http://localhost:2792/api/hooks/claude -H 'Content-Type: application/json' -d @-"
+            "command": "curl -s -X POST http://localhost:2791/api/hooks/claude -H 'Content-Type: application/json' -d @-"
           }
         ]
       }
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "curl -s -X POST http://localhost:2792/api/hooks/claude -H 'Content-Type: application/json' -d @-"
+            "command": "curl -s -X POST http://localhost:2791/api/hooks/claude -H 'Content-Type: application/json' -d @-"
           }
         ]
       }
@@ -28,7 +28,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "curl -s -X POST http://localhost:2792/api/hooks/claude -H 'Content-Type: application/json' -d @-"
+            "command": "curl -s -X POST http://localhost:2791/api/hooks/claude -H 'Content-Type: application/json' -d @-"
           }
         ]
       }
@@ -38,7 +38,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "curl -s -X POST http://localhost:2792/api/hooks/claude -H 'Content-Type: application/json' -d @-"
+            "command": "curl -s -X POST http://localhost:2791/api/hooks/claude -H 'Content-Type: application/json' -d @-"
           }
         ]
       }
@@ -48,7 +48,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "curl -s -X POST http://localhost:2792/api/hooks/claude -H 'Content-Type: application/json' -d @-"
+            "command": "curl -s -X POST http://localhost:2791/api/hooks/claude -H 'Content-Type: application/json' -d @-"
           }
         ]
       }
@@ -58,7 +58,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "curl -s -X POST http://localhost:2792/api/hooks/claude -H 'Content-Type: application/json' -d @-"
+            "command": "curl -s -X POST http://localhost:2791/api/hooks/claude -H 'Content-Type: application/json' -d @-"
           }
         ]
       }
@@ -68,7 +68,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "curl -s -X POST http://localhost:2792/api/hooks/claude -H 'Content-Type: application/json' -d @-"
+            "command": "curl -s -X POST http://localhost:2791/api/hooks/claude -H 'Content-Type: application/json' -d @-"
           }
         ]
       }
@@ -78,7 +78,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "curl -s -X POST http://localhost:2792/api/hooks/claude -H 'Content-Type: application/json' -d @-"
+            "command": "curl -s -X POST http://localhost:2791/api/hooks/claude -H 'Content-Type: application/json' -d @-"
           }
         ]
       }
@@ -88,7 +88,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "curl -s -X POST http://localhost:2792/api/hooks/claude -H 'Content-Type: application/json' -d @-"
+            "command": "curl -s -X POST http://localhost:2791/api/hooks/claude -H 'Content-Type: application/json' -d @-"
           }
         ]
       }
@@ -98,7 +98,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "curl -s -X POST http://localhost:2792/api/hooks/claude -H 'Content-Type: application/json' -d @-"
+            "command": "curl -s -X POST http://localhost:2791/api/hooks/claude -H 'Content-Type: application/json' -d @-"
           }
         ]
       }
@@ -108,7 +108,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "curl -s -X POST http://localhost:2792/api/hooks/claude -H 'Content-Type: application/json' -d @-"
+            "command": "curl -s -X POST http://localhost:2791/api/hooks/claude -H 'Content-Type: application/json' -d @-"
           }
         ]
       }
@@ -118,7 +118,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "curl -s -X POST http://localhost:2792/api/hooks/claude -H 'Content-Type: application/json' -d @-"
+            "command": "curl -s -X POST http://localhost:2791/api/hooks/claude -H 'Content-Type: application/json' -d @-"
           }
         ]
       }
@@ -128,7 +128,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "curl -s -X POST http://localhost:2792/api/hooks/claude -H 'Content-Type: application/json' -d @-"
+            "command": "curl -s -X POST http://localhost:2791/api/hooks/claude -H 'Content-Type: application/json' -d @-"
           }
         ]
       }
@@ -138,7 +138,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "curl -s -X POST http://localhost:2792/api/hooks/claude -H 'Content-Type: application/json' -d @-"
+            "command": "curl -s -X POST http://localhost:2791/api/hooks/claude -H 'Content-Type: application/json' -d @-"
           }
         ]
       }
@@ -148,7 +148,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "curl -s -X POST http://localhost:2792/api/hooks/claude -H 'Content-Type: application/json' -d @-"
+            "command": "curl -s -X POST http://localhost:2791/api/hooks/claude -H 'Content-Type: application/json' -d @-"
           }
         ]
       }
@@ -158,7 +158,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "curl -s -X POST http://localhost:2792/api/hooks/claude -H 'Content-Type: application/json' -d @-"
+            "command": "curl -s -X POST http://localhost:2791/api/hooks/claude -H 'Content-Type: application/json' -d @-"
           }
         ]
       }
@@ -168,7 +168,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "curl -s -X POST http://localhost:2792/api/hooks/claude -H 'Content-Type: application/json' -d @-"
+            "command": "curl -s -X POST http://localhost:2791/api/hooks/claude -H 'Content-Type: application/json' -d @-"
           }
         ]
       }
@@ -178,7 +178,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "curl -s -X POST http://localhost:2792/api/hooks/claude -H 'Content-Type: application/json' -d @-"
+            "command": "curl -s -X POST http://localhost:2791/api/hooks/claude -H 'Content-Type: application/json' -d @-"
           }
         ]
       }
@@ -188,7 +188,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "curl -s -X POST http://localhost:2792/api/hooks/claude -H 'Content-Type: application/json' -d @-"
+            "command": "curl -s -X POST http://localhost:2791/api/hooks/claude -H 'Content-Type: application/json' -d @-"
           }
         ]
       }
@@ -198,7 +198,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "curl -s -X POST http://localhost:2792/api/hooks/claude -H 'Content-Type: application/json' -d @-"
+            "command": "curl -s -X POST http://localhost:2791/api/hooks/claude -H 'Content-Type: application/json' -d @-"
           }
         ]
       }
@@ -208,7 +208,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "curl -s -X POST http://localhost:2792/api/hooks/claude -H 'Content-Type: application/json' -d @-"
+            "command": "curl -s -X POST http://localhost:2791/api/hooks/claude -H 'Content-Type: application/json' -d @-"
           }
         ]
       }
@@ -218,7 +218,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "curl -s -X POST http://localhost:2792/api/hooks/claude -H 'Content-Type: application/json' -d @-"
+            "command": "curl -s -X POST http://localhost:2791/api/hooks/claude -H 'Content-Type: application/json' -d @-"
           }
         ]
       }
@@ -227,7 +227,7 @@
   "mcpServers": {
     "tsunagi": {
       "type": "http",
-      "url": "http://localhost:2792/api/mcp"
+      "url": "http://localhost:2791/api/mcp"
     }
   }
 }

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@fastify/cors": "^11.2.0",
+    "@fastify/http-proxy": "^11.5.0",
     "@libsql/client": "0.8.1",
     "@minimalcorp/tsunagi-shared": "*",
     "@modelcontextprotocol/sdk": "^1.27.1",

--- a/apps/server/src/basic-auth.ts
+++ b/apps/server/src/basic-auth.ts
@@ -1,0 +1,76 @@
+import crypto from 'node:crypto';
+import type { IncomingHttpHeaders } from 'node:http';
+
+/**
+ * Basic 認証。`TSUNAGI_BASIC_AUTH_USER` と `TSUNAGI_BASIC_AUTH_PASSWORD` が
+ * 両方設定されているときだけ有効化する（cloudflared 等で外部公開する際の保護）。
+ *
+ * 単一ポート集約の都合上、cloudflared はアプリと同じ `localhost` から Fastify へ
+ * 接続するため、外部アクセスもローカルの内部連携も IP 上は loopback に見える。
+ * そこで「外部 = Cloudflare 経由」を Cloudflare が付与するヘッダで判別し、外部からは
+ * すべて認証必須にしつつ、ローカルマシン上の Claude Code プラグイン連携
+ * (hooks / MCP) や cli の死活監視だけは認証なしで通す。
+ */
+
+// ローカルからのみ認証を免除する内部連携エンドポイント。外部(cloudflared)からは
+// これらであっても認証必須にする。
+const LOCAL_EXEMPT_PREFIXES = ['/health', '/api/hooks', '/api/internal', '/api/mcp'];
+
+const LOOPBACK_ADDRESSES = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1']);
+
+export interface BasicAuth {
+  /** クライアントへ返す WWW-Authenticate ヘッダ値 */
+  readonly challenge: string;
+  /** Authorization ヘッダが想定値と一致するか（定数時間比較） */
+  isValidHeader(header: string | undefined): boolean;
+  /** リクエストを通してよいか（認証成功 or ローカル内部連携の免除） */
+  isAuthorized(
+    headers: IncomingHttpHeaders,
+    url: string | undefined,
+    remoteAddress: string | undefined
+  ): boolean;
+}
+
+export function createBasicAuth(env: NodeJS.ProcessEnv = process.env): BasicAuth | null {
+  const user = env.TSUNAGI_BASIC_AUTH_USER;
+  const password = env.TSUNAGI_BASIC_AUTH_PASSWORD;
+  if (!user || !password) return null;
+
+  const expected = `Basic ${Buffer.from(`${user}:${password}`).toString('base64')}`;
+  const expectedBuf = Buffer.from(expected);
+
+  const isValidHeader = (header: string | undefined): boolean => {
+    if (!header) return false;
+    const given = Buffer.from(header);
+    // 長さが異なると timingSafeEqual が throw するため先にガード（長さ差のみ漏れる）。
+    return given.length === expectedBuf.length && crypto.timingSafeEqual(given, expectedBuf);
+  };
+
+  // Cloudflare(cloudflared)経由のリクエストには Cloudflare が必ず付与するヘッダが付く。
+  // Cloudflare はクライアント指定の cf-connecting-ip を上書きするため、外部からは
+  // 「ローカルに偽装」できない。
+  const isViaCloudflare = (headers: IncomingHttpHeaders): boolean =>
+    Boolean(headers['cf-connecting-ip'] || headers['cf-ray'] || headers['x-forwarded-for']);
+
+  const isLoopback = (remoteAddress: string | undefined): boolean =>
+    !!remoteAddress && LOOPBACK_ADDRESSES.has(remoteAddress);
+
+  const isLocalExemptPath = (url: string | undefined): boolean => {
+    const path = (url ?? '').split('?')[0];
+    return LOCAL_EXEMPT_PREFIXES.some((p) => path === p || path.startsWith(`${p}/`));
+  };
+
+  return {
+    challenge: 'Basic realm="tsunagi", charset="UTF-8"',
+    isValidHeader,
+    isAuthorized(headers, url, remoteAddress) {
+      if (isValidHeader(headers['authorization'])) return true;
+      // 認証情報が無くても、loopback かつ Cloudflare 経由でない（=同一マシン直結の）
+      // 内部連携エンドポイントだけは許可する。
+      if (isLoopback(remoteAddress) && !isViaCloudflare(headers) && isLocalExemptPath(url)) {
+        return true;
+      }
+      return false;
+    },
+  };
+}

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,5 +1,8 @@
+import net from 'node:net';
+
 import Fastify from 'fastify';
 import fastifyCors from '@fastify/cors';
+import httpProxy from '@fastify/http-proxy';
 import { Server as SocketIOServer } from 'socket.io';
 
 import { tasksRoutes } from './routes/tasks.js';
@@ -14,14 +17,22 @@ import { hooksRoutes } from './routes/hooks.js';
 import { mcpRoutes } from './routes/mcp.js';
 import { terminalRoutes } from './routes/terminal.js';
 import { editorRoutes } from './routes/editor.js';
+import { createBasicAuth } from './basic-auth.js';
 
-const PORT = 2792;
+// Fastify は単一の公開エンドポイント。Next.js は内部ポートで動かしプロキシする。
+const PORT = Number(process.env.PORT) || 2791;
+const NEXT_PORT = Number(process.env.TSUNAGI_NEXT_PORT) || 2792;
 
 const extraOrigins = (process.env.TSUNAGI_EXTRA_CORS_ORIGINS ?? '')
   .split(',')
   .map((s) => s.trim())
   .filter(Boolean);
-const corsOrigins = ['http://localhost:2791', ...extraOrigins];
+// 本番(cloudflared 等)は同一オリジンで CORS 不要。dev は Next を 2792 で直接開く
+// ため、その origin からの cross-origin リクエストを許可する。
+const corsOrigins = [`http://localhost:${NEXT_PORT}`, ...extraOrigins];
+
+// TSUNAGI_BASIC_AUTH_USER / TSUNAGI_BASIC_AUTH_PASSWORD が両方ある時だけ有効。
+const basicAuth = createBasicAuth();
 
 async function start() {
   const fastify = Fastify({
@@ -35,9 +46,30 @@ async function start() {
     methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
   });
 
+  // Basic 認証（有効時のみ）。CORS の後に登録することで preflight(OPTIONS) は
+  // @fastify/cors が先に応答し、認証で弾かれない。
+  if (basicAuth) {
+    fastify.addHook('onRequest', async (request, reply) => {
+      if (basicAuth.isAuthorized(request.headers, request.url, request.socket.remoteAddress)) {
+        return;
+      }
+      reply
+        .header('WWW-Authenticate', basicAuth.challenge)
+        .code(401)
+        .send('Authentication required');
+      return reply;
+    });
+  }
+
   const io = new SocketIOServer(fastify.server, {
     transports: ['websocket'],
     cors: { origin: corsOrigins },
+    // Basic 認証（有効時）。WS ハンドシェイクの Authorization をブラウザがキャッシュ
+    // 済み認証情報として送るため、ここで検証する。
+    allowRequest: basicAuth
+      ? (req, callback) =>
+          callback(null, basicAuth.isAuthorized(req.headers, req.url, req.socket.remoteAddress))
+      : undefined,
     // 死んだ接続（スリープ・ネットワーク断等）を早めに検出して、ぶら下がった socket が
     // 保持する PTY の onData/onExit ハンドラを早く解放する。既定 (25s/20s) では検出までに
     // 最大 ~45s かかり、その間ゾンビ socket がリスナーを溜め込み出力が多重化する。
@@ -60,6 +92,48 @@ async function start() {
   await fastify.register(mcpRoutes, { prefix: '/api' });
   await fastify.register(terminalRoutes, { prefix: '/api' });
   await fastify.register(editorRoutes, { prefix: '/api' });
+
+  // catch-all リバースプロキシ: /api・/socket.io・/health 以外を内部 Next.js へ転送。
+  // - /api/* と /health は上で定義済みルートが wildcard より優先される。
+  // - /socket.io は Socket.IO が HTTP サーバ層で先取りするためここには来ない。
+  // - websocket は false。HMR は下の透過リレーで、Socket.IO は engine.io が終端する。
+  await fastify.register(httpProxy, {
+    upstream: `http://localhost:${NEXT_PORT}`,
+    prefix: '/',
+    websocket: false,
+  });
+
+  // 開発時のみ: Next.js の HMR(WebSocket = /_next/webpack-hmr) を 2791 経由でも
+  // 使えるよう透過 TCP リレーする。これにより dev も本番と同じく単一ポート(2791)で
+  // 完結し、HMR / API / Socket.IO がすべて同一オリジンで動く。
+  //
+  // 注意: @fastify/http-proxy の websocket:true は upgrade を Fastify router 経由で
+  // ディスパッチするため、/socket.io の upgrade まで catch-all ルートが拾い例外を
+  // 投げる（Socket.IO 接続毎にエラーログ）。そのため WS は自前で /_next/webpack-hmr
+  // だけを対象にし、/socket.io には一切触れず engine.io に委ねる。
+  // 本番(standalone Next)は HMR が無いので何もしない。
+  if (process.env.NODE_ENV !== 'production') {
+    fastify.server.on('upgrade', (req, socket, head) => {
+      if (!req.url?.startsWith('/_next/webpack-hmr')) return;
+      if (basicAuth && !basicAuth.isAuthorized(req.headers, req.url, req.socket.remoteAddress)) {
+        socket.destroy();
+        return;
+      }
+      const upstream = net.connect(NEXT_PORT, '127.0.0.1', () => {
+        upstream.write(`${req.method} ${req.url} HTTP/1.1\r\n`);
+        const raw = req.rawHeaders;
+        for (let i = 0; i < raw.length; i += 2) {
+          upstream.write(`${raw[i]}: ${raw[i + 1]}\r\n`);
+        }
+        upstream.write('\r\n');
+        if (head?.length) upstream.write(head);
+        socket.pipe(upstream);
+        upstream.pipe(socket);
+      });
+      upstream.on('error', () => socket.destroy());
+      socket.on('error', () => upstream.destroy());
+    });
+  }
 
   await fastify.listen({ port: PORT, host: '0.0.0.0' });
   console.log(`Fastify server running on port ${PORT}`);

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -97,10 +97,14 @@ async function start() {
   // - /api/* と /health は上で定義済みルートが wildcard より優先される。
   // - /socket.io は Socket.IO が HTTP サーバ層で先取りするためここには来ない。
   // - websocket は false。HMR は下の透過リレーで、Socket.IO は engine.io が終端する。
+  // - OPTIONS は除外。@fastify/cors が `OPTIONS *` を登録済みで、proxy が同じ
+  //   `OPTIONS /*` を登録すると "Method 'OPTIONS' already declared" で起動失敗する。
+  //   preflight は cors が処理するため proxy 側で OPTIONS を扱う必要はない。
   await fastify.register(httpProxy, {
     upstream: `http://localhost:${NEXT_PORT}`,
     prefix: '/',
     websocket: false,
+    httpMethods: ['DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT'],
   });
 
   // 開発時のみ: Next.js の HMR(WebSocket = /_next/webpack-hmr) を 2791 経由でも

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,9 +5,9 @@
   "description": "Next.js UI for tsunagi",
   "type": "module",
   "scripts": {
-    "dev": "next dev -p 2791",
+    "dev": "next dev -p 2792",
     "build": "next build",
-    "start": "next start -p 2791",
+    "start": "next start -p 2792",
     "lint": "eslint",
     "type-check": "tsc --noEmit"
   },

--- a/apps/web/src/lib/api-url.ts
+++ b/apps/web/src/lib/api-url.ts
@@ -1,36 +1,43 @@
 /**
  * Resolve the base URL of the tsunagi-server (Fastify) instance.
  *
- * - Browser: ユーザがアクセスしている hostname + Fastify の固定ポート (2792)
- *   これにより localhost / LAN / SSH tunnel いずれの経路でも動く。
- * - Node.js (SSR / Server Components): 環境変数 `NEXT_PUBLIC_TSUNAGI_SERVER_URL` か
- *   フォールバックの `http://localhost:2792`。
+ * Fastify (port 2791) を単一の公開エンドポイントとし、API / Socket.IO は自前で
+ * 処理、それ以外は内部の Next.js (port 2792) へリバースプロキシする構成。
+ * これにより cloudflared など「単一ポートのみ公開」のトンネル越しでも、
+ * Web・API・WebSocket がすべて同一オリジンで成立する。
  *
- * tsunagi は完全 local-only のアプリで、Web UI (port 2791) から Fastify
- * (port 2792) を直接呼ぶ。Next.js には rewrites を一切書かないため、UI
- * 側のすべての fetch / Socket.IO 接続はこのヘルパ経由にする。
+ * - Browser: ユーザがアクセスしているオリジンをそのまま使う（同一オリジン）。
+ *   localhost / LAN / cloudflared / SSH tunnel いずれの経路でも動き、
+ *   http/https・ws/wss も window.location.protocol から正しく導出される。
+ * - Node.js (SSR / Server Components): 環境変数 `NEXT_PUBLIC_TSUNAGI_SERVER_URL`
+ *   か、フォールバックの `http://localhost:2791`（同一マシンの Fastify）。
+ *
+ * 開発時も本番と同じく Fastify 入口 (localhost:2791 / docker は host:2891) に
+ * アクセスする。HMR(WebSocket) は Fastify が Next へ透過リレーするため、同一
+ * オリジンのまま動く。Next 直アクセス(2792)用の上書きは不要。
+ * `NEXT_PUBLIC_TSUNAGI_SERVER_URL` は reverse proxy 等で別オリジンに向けたい
+ * 場合の明示上書きとしてのみ残す。
  */
 
-const FASTIFY_PORT = 2792;
-
 export function getServerUrl(): string {
-  // 明示的な上書き（Docker ephemeral 環境、reverse proxy 等）
+  // 明示的な上書き（開発時の Next 直アクセス、reverse proxy 等）
   const override = process.env.NEXT_PUBLIC_TSUNAGI_SERVER_URL;
   if (override) return override;
 
   if (typeof window !== 'undefined') {
-    const { protocol, hostname } = window.location;
-    return `${protocol}//${hostname}:${FASTIFY_PORT}`;
+    const { protocol, host } = window.location;
+    // host はポート込み。同一オリジンなので追加のポート付与はしない。
+    return `${protocol}//${host}`;
   }
-  return `http://localhost:${FASTIFY_PORT}`;
+  return 'http://localhost:2791';
 }
 
 /**
  * Compose a fully qualified URL for an API endpoint.
  *
  * @example
- *   apiUrl('/api/tasks')                  → http://localhost:2792/api/tasks
- *   apiUrl('/api/tasks/' + id + '/tabs')  → http://localhost:2792/api/tasks/<id>/tabs
+ *   apiUrl('/api/tasks')                  → <origin>/api/tasks
+ *   apiUrl('/api/tasks/' + id + '/tabs')  → <origin>/api/tasks/<id>/tabs
  */
 export function apiUrl(pathWithLeadingSlash: string): string {
   return `${getServerUrl()}${pathWithLeadingSlash}`;

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -19,7 +23,9 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
   "include": [
@@ -28,7 +34,10 @@
     "**/*.tsx",
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts",
-    "**/*.mts"
+    "**/*.mts",
+    ".next/dev/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,11 +4,14 @@
 
 ## ポートマッピング
 
-| サービス         | ホスト | container |
-| ---------------- | ------ | --------- |
-| Web (Next.js)    | 2891   | 2791      |
-| Server (Fastify) | 2892   | 2792      |
-| Docs             | 2893   | 2793      |
+Fastify (container 2791 → host 2891) が単一入口。Web/API/WebSocket をまとめて配信し、
+それ以外は内部 Next.js (2792) へプロキシする。**アクセスは host:2891 のみ**でよい。
+
+| サービス           | ホスト | container | 備考                                 |
+| ------------------ | ------ | --------- | ------------------------------------ |
+| 単一入口 (Fastify) | 2891   | 2791      | Web/API/WS をここで配信。アクセス先  |
+| Next.js (内部)     | 2892   | 2792      | Fastify がプロキシ。直接アクセス不要 |
+| Docs               | 2893   | 2793      |                                      |
 
 ## 前提条件
 
@@ -39,9 +42,23 @@ make up
 
 起動後:
 
-- Web UI: http://localhost:2891
-- API: http://localhost:2892
+- Web UI / API / WebSocket: http://localhost:2891 （すべてここ経由）
 - Docs: http://localhost:2893
+
+### Basic 認証付きで起動（cloudflared 等で外部公開する場合）
+
+外部公開時は認証なしだと脆弱なため、Basic 認証を有効化して起動する。
+`TSUNAGI_BASIC_AUTH_USER` と `TSUNAGI_BASIC_AUTH_PASSWORD` の **両方** を渡すと有効化される
+（どちらか欠けると無効）。
+
+```bash
+TSUNAGI_BASIC_AUTH_USER=tsunagi TSUNAGI_BASIC_AUTH_PASSWORD=xxxx make up
+```
+
+- 外部（cloudflared 経由）からのアクセスはページ/API/WS すべて認証必須になる
+- ローカルマシン上の Claude Code 連携 (hooks / MCP) や死活監視は認証なしで通る
+- 本番ビルド版でも同様に渡せる: `TSUNAGI_BASIC_AUTH_USER=tsunagi TSUNAGI_BASIC_AUTH_PASSWORD=xxxx make up-prd`
+- 値はコミットされない（compose は環境変数を参照するだけ）。リポジトリ root の `.env`（gitignore 対象）に書いてもよい
 
 ### ログ確認
 

--- a/docker/compose.prd.yml
+++ b/docker/compose.prd.yml
@@ -12,10 +12,15 @@ services:
       - ${SSH_SOCK_HOST}:${SSH_SOCK_CONTAINER}
       - ~/.gitconfig:/home/node/.gitconfig:ro
     environment:
-      - NEXT_PUBLIC_TSUNAGI_SERVER_URL=http://localhost:2892
+      # Fastify(container 2791 → host 2891)を単一入口に同一オリジン配信するため、
+      # API/WS 向き先の上書きは不要。host:2891 でアクセスする。
       - TSUNAGI_EXTRA_CORS_ORIGINS=http://localhost:2891
       - SSH_AUTH_SOCK=${SSH_SOCK_CONTAINER}
       - HUSKY=0
+      # Basic 認証: ホストで両方 export して `make up-prd` すると有効化される（未設定なら無効）。
+      #   例: TSUNAGI_BASIC_AUTH_USER=tsunagi TSUNAGI_BASIC_AUTH_PASSWORD=xxxx make up-prd
+      - TSUNAGI_BASIC_AUTH_USER=${TSUNAGI_BASIC_AUTH_USER:-}
+      - TSUNAGI_BASIC_AUTH_PASSWORD=${TSUNAGI_BASIC_AUTH_PASSWORD:-}
     ports:
       - '2891:2791'
       - '2892:2792'

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -12,9 +12,14 @@ services:
       - ${SSH_SOCK_HOST}:${SSH_SOCK_CONTAINER}
       - ~/.gitconfig:/home/node/.gitconfig:ro
     environment:
-      - NEXT_PUBLIC_TSUNAGI_SERVER_URL=http://localhost:2892
+      # Fastify(container 2791 → host 2891)を単一入口に同一オリジン配信するため、
+      # API/WS 向き先の上書きは不要。host:2891 でアクセスする。
       - TSUNAGI_EXTRA_CORS_ORIGINS=http://localhost:2891
       - SSH_AUTH_SOCK=${SSH_SOCK_CONTAINER}
+      # Basic 認証: ホストで両方 export して `make up` すると有効化される（未設定なら無効）。
+      #   例: TSUNAGI_BASIC_AUTH_USER=tsunagi TSUNAGI_BASIC_AUTH_PASSWORD=xxxx make up
+      - TSUNAGI_BASIC_AUTH_USER=${TSUNAGI_BASIC_AUTH_USER:-}
+      - TSUNAGI_BASIC_AUTH_PASSWORD=${TSUNAGI_BASIC_AUTH_PASSWORD:-}
     ports:
       - '2891:2791'
       - '2892:2792'

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
       ],
       "dependencies": {
         "@fastify/cors": "^11.2.0",
+        "@fastify/http-proxy": "^11.5.0",
         "@libsql/client": "0.8.1",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@prisma/adapter-libsql": "^7.3.0",
@@ -298,6 +299,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@fastify/cors": "^11.2.0",
+        "@fastify/http-proxy": "^11.5.0",
         "@libsql/client": "0.8.1",
         "@minimalcorp/tsunagi-shared": "*",
         "@modelcontextprotocol/sdk": "^1.27.1",
@@ -1832,6 +1834,28 @@
       ],
       "license": "MIT"
     },
+    "node_modules/@fastify/http-proxy": {
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/@fastify/http-proxy/-/http-proxy-11.5.0.tgz",
+      "integrity": "sha512-UxmqkVvTRzbN8A8xSRBmKFhGufhFGDxoBCzPkp5+GDYRb4ew/WwmsZTYd13yJ3TWyOlpRhoQVVLHfcb0wPVkCg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/reply-from": "^12.6.2",
+        "fast-querystring": "^1.1.2",
+        "fastify-plugin": "^5.1.0",
+        "ws": "^8.18.3"
+      }
+    },
     "node_modules/@fastify/merge-json-schemas": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.2.1.tgz",
@@ -1869,6 +1893,31 @@
       "dependencies": {
         "@fastify/forwarded": "^3.0.0",
         "ipaddr.js": "^2.1.0"
+      }
+    },
+    "node_modules/@fastify/reply-from": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/@fastify/reply-from/-/reply-from-12.6.2.tgz",
+      "integrity": "sha512-FhMvsRJa4HMG0q0/Yi06sgwVFd/Wc8E/+RbHsqB0Q+883C66RPrS6qwZKBPje2mVzsyEb9sjq7wlyvi35zRW0A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/error": "^4.0.0",
+        "end-of-stream": "^1.4.4",
+        "fast-content-type-parse": "^3.0.0",
+        "fast-querystring": "^1.1.2",
+        "fastify-plugin": "^5.0.1",
+        "toad-cache": "^3.7.0",
+        "undici": "^7.0.0"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -8748,6 +8797,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/engine.io": {
       "version": "6.6.6",
       "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.6.tgz",
@@ -9957,6 +10015,22 @@
       "engines": {
         "node": ">=8.0.0"
       }
+    },
+    "node_modules/fast-content-type-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
+      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/fast-decode-uri-component": {
       "version": "1.0.1",
@@ -18329,6 +18403,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {


### PR DESCRIPTION
- Fastify(2791) を単一公開ポートにし、/api・/socket.io・/health 以外を 内部 Next.js(2792) へリバースプロキシ（同一オリジン配信）
- Web の API/WS 接続先を同一オリジン化（:2792 ハードコード撤廃）
- dev も Fastify 入口経由に統一。HMR(WebSocket) は /_next/webpack-hmr を 透過リレーして単一ポートのまま動作させる
- TSUNAGI_BASIC_AUTH_USER/PASSWORD 両方設定時のみ Basic 認証を有効化。 外部(cloudflared 経由)は全経路で認証必須、ローカルの内部連携 (hooks/MCP/health) は loopback かつ Cloudflare ヘッダ無しの時のみ免除
- plugin hooks/MCP の API 接続先を 2791 へ更新
- docker compose で Basic 認証 env をパススルー、README に起動例を追記