### PR TITLE
fix: 認証付き公開時に iOS から Socket.IO 接続できない問題を修正 (polling 併用)

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -62,10 +62,13 @@ async function start() {
   }
 
   const io = new SocketIOServer(fastify.server, {
-    transports: ['websocket'],
+    // polling を許可しておく。iOS Safari/Chrome(WebKit) は Basic 認証のキャッシュ
+    // 資格情報を WebSocket ハンドシェイクには付与しない既知の挙動があり、WS のみだと
+    // 認証付き公開時に iOS 端末から接続できず "connecting..." のまま固まる。polling は
+    // XHR なので Authorization が乗り、認証を通過できる（デスクトップは WS に自動昇格）。
+    transports: ['polling', 'websocket'],
     cors: { origin: corsOrigins },
-    // Basic 認証（有効時）。WS ハンドシェイクの Authorization をブラウザがキャッシュ
-    // 済み認証情報として送るため、ここで検証する。
+    // Basic 認証（有効時）。polling は XHR、WS はハンドシェイクの Authorization を検証する。
     allowRequest: basicAuth
       ? (req, callback) =>
           callback(null, basicAuth.isAuthorized(req.headers, req.url, req.socket.remoteAddress))

--- a/apps/web/src/components/TerminalView.tsx
+++ b/apps/web/src/components/TerminalView.tsx
@@ -465,7 +465,9 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
       socketRef.current.disconnect();
     }
 
-    const socket = io(getServerUrl(), { transports: ['websocket'] });
+    // polling を含める。iOS(WebKit) は Basic 認証情報を WS ハンドシェイクに付与しない
+    // ため、認証付き公開時は polling(XHR) でないと接続できない。デスクトップは WS に昇格。
+    const socket = io(getServerUrl(), { transports: ['polling', 'websocket'] });
     socketRef.current = socket;
     // reused時: 最初のoutputイベント（リングバッファ）受信後にリサイズを再送する
     let firstMessageHandled = false;

--- a/apps/web/src/hooks/useTabStatusEvents.ts
+++ b/apps/web/src/hooks/useTabStatusEvents.ts
@@ -42,7 +42,8 @@ export function useTabStatusEvents(
 
   const ensureConnected = useCallback(() => {
     if (!socketRef.current) {
-      const socket = io(getServerUrl(), { transports: ['websocket'] });
+      // polling 併用: iOS(WebKit) は Basic 認証情報を WS に付与しないため（認証付き公開時の iOS 対策）
+      const socket = io(getServerUrl(), { transports: ['polling', 'websocket'] });
       socketRef.current = socket;
 
       socket.on(

--- a/apps/web/src/hooks/useTaskEvents.ts
+++ b/apps/web/src/hooks/useTaskEvents.ts
@@ -20,7 +20,8 @@ export function useTaskEvents(callbacks: TaskEventCallbacks) {
   });
 
   useEffect(() => {
-    const socket = io(getServerUrl(), { transports: ['websocket'] });
+    // polling 併用: iOS(WebKit) は Basic 認証情報を WS に付与しないため（認証付き公開時の iOS 対策）
+    const socket = io(getServerUrl(), { transports: ['polling', 'websocket'] });
     socketRef.current = socket;
 
     socket.on('task:created', ({ task }: { task: Task }) => {

--- a/apps/web/src/hooks/useTerminalTodos.ts
+++ b/apps/web/src/hooks/useTerminalTodos.ts
@@ -24,7 +24,8 @@ export function useTerminalTodos(runningTabIds: string[]): TabTodosMap {
   useEffect(() => {
     // 接続がなければ作成
     if (!socketRef.current) {
-      const socket = io(getServerUrl(), { transports: ['websocket'] });
+      // polling 併用: iOS(WebKit) は Basic 認証情報を WS に付与しないため（認証付き公開時の iOS 対策）
+      const socket = io(getServerUrl(), { transports: ['polling', 'websocket'] });
       socketRef.current = socket;
 
       socket.on('todos-updated', ({ sessionId, todos }: { sessionId: string; todos: Todo[] }) => {


### PR DESCRIPTION
iOS Safari/Chrome(WebKit) は HTTP Basic 認証のキャッシュ資格情報を WebSocket ハンドシェイクに付与しない。そのため transports を websocket 限定にしていると、 Basic 認証付きで cloudflared 公開した際に iOS 端末からだけ Socket.IO が接続できず ターミナル等が "connecting..." のまま固まっていた（デスクトップは WS に Authorization が乗るため接続可能）。

クライアント/サーバとも transports に polling を追加。polling は XHR のため iOS でも Authorization が送られ認証を通過でき、デスクトップは従来どおり WS へ自動昇格する。 catch-all proxy 環境でも engine.io が /socket.io を先取りするため polling リクエストが Next へ転送されないこと、Basic 認証(有効/無効)の双方で期待通り動作することを検証済み。