### PR TITLE
fix: Basic 認証有効時に Ctrl+G で Monaco Editor が開かない問題を修正

### DIFF
--- a/apps/server/src/basic-auth.ts
+++ b/apps/server/src/basic-auth.ts
@@ -14,7 +14,11 @@ import type { IncomingHttpHeaders } from 'node:http';
 
 // ローカルからのみ認証を免除する内部連携エンドポイント。外部(cloudflared)からは
 // これらであっても認証必須にする。
-const LOCAL_EXEMPT_PREFIXES = ['/health', '/api/hooks', '/api/internal', '/api/mcp'];
+// - /api/editor: Ctrl+G で起動する monaco-editor.sh が PTY 内(=同一マシン)から
+//   localhost 経由で叩く。これを免除しないと Basic 認証有効時に 401 となり
+//   Monaco Editor が開かない。外部ブラウザからの /complete は cf ヘッダが付くため
+//   引き続き認証必須。
+const LOCAL_EXEMPT_PREFIXES = ['/health', '/api/hooks', '/api/internal', '/api/mcp', '/api/editor'];
 
 const LOOPBACK_ADDRESSES = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1']);
 


### PR DESCRIPTION
cloudflared 公開で Basic 認証を有効にすると、PTY 内(同一マシン)から localhost 経由で /api/editor/session を叩く monaco-editor.sh が 401 で弾かれ、editor:open が配信されず Modal が開かなかった。/api/editor が LOCAL_EXEMPT_PREFIXES に 含まれていなかったのが原因。

- basic-auth.ts: LOCAL_EXEMPT_PREFIXES に /api/editor を追加
- ループバック かつ 非 Cloudflare のみ免除。外部(cf ヘッダ付き)は引き続き 401