### PR TITLE
fix: iPad物理キーボードでの日本語IME入力が二重送信される問題を修正

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "next dev --port 2793",
     "build": "next build",
-    "postbuild": "node scripts/fix-html-lang.js && pagefind --site out --output-subdir _pagefind",
+    "postbuild": "node scripts/fix-html-lang.js && (pagefind --site out --output-subdir _pagefind || echo '[skip] pagefind unavailable on this platform (linux-arm64)')",
     "start": "next start --port 2793",
     "lint": "eslint",
     "type-check": "tsc --noEmit"

--- a/apps/web/src/components/TerminalView.tsx
+++ b/apps/web/src/components/TerminalView.tsx
@@ -176,6 +176,9 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
   // xterm 初期化（マウント時のみ）
   useEffect(() => {
     if (!containerRef.current) return;
+    // cleanup でも参照するため、effect 実行時点の要素をローカルに退避する
+    // （ref は cleanup 実行時に変化している可能性があるため）。
+    const container = containerRef.current;
 
     const term = new Terminal({
       cursorBlink: true,
@@ -219,9 +222,31 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
       }
     });
 
-    // xterm.js は CompositionHelper 内で composition 中のキーストロークを内部で抑制し、
-    // compositionend 後の setTimeout で確定テキストのみ triggerDataEvent → onData で通知する。
-    // そのため我々が compositionstart/end を監視して onData をガードする必要はない。
+    // iPadOS Safari + ハードウェアキーボードは IME 確定時に compositionend を2回発火する
+    // （1回目: data=確定文字 / 2回目: data="" 約20ms後）。xterm.js の CompositionHelper は
+    // compositionend ごとに確定テキストを onData へ送るため、2回目で同じ文字列が再送され
+    // PTY に二重入力される（例:「あいうえお」→「あいうえおあいうえお」）。
+    // 2つの onData はどちらも compositionend 後（isComposing=false）に発火するため、
+    // composition 中を抑制するガードでは防げない。
+    // 対策: 余分な2回目（空データ かつ 直前 compositionend から極短時間）を、xterm の
+    // textarea リスナーへ届く前に capture フェーズ（親要素）で握りつぶす。
+    // - 確定文字を持つ1回目は必ず通過する
+    // - ソフトウェアキーボード/デスクトップは compositionend 1回のみのため影響なし
+    // - IME キャンセル時の空 compositionend は直前に確定が無いため抑制されない
+    let lastCompositionEndAt = 0;
+    const DUP_COMPOSITION_END_MS = 100; // 実測の二重発火間隔は約18ms
+    const onCompositionEndCapture = (e: Event) => {
+      const now = performance.now();
+      if (
+        (e as CompositionEvent).data === '' &&
+        now - lastCompositionEndAt < DUP_COMPOSITION_END_MS
+      ) {
+        e.stopImmediatePropagation();
+        return;
+      }
+      lastCompositionEndAt = now;
+    };
+    container.addEventListener('compositionend', onCompositionEndCapture, true);
 
     const observer = new ResizeObserver(() => {
       // editor session (Ctrl+G Monaco modal) 中は fit / sendResize を一切行わない。
@@ -246,6 +271,7 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
     return () => {
       abortController.abort();
       observer.disconnect();
+      container.removeEventListener('compositionend', onCompositionEndCapture, true);
       onDataDisposeRef.current?.dispose();
       onDataDisposeRef.current = null;
       term.dispose();


### PR DESCRIPTION
## 概要

iPad に USB 物理キーボードを接続して日本語入力を行うと、確定した文字が二重に入力される問題を修正します（例:「あいうえお」+Enter →「あいうえおあいうえお」）。

## 原因

実機ログ（compositionend / input / onData の時系列）で確定しました。

iPadOS Safari + ハードウェアキーボードでは、IME 確定時に `compositionend` が **2回発火** します（1回目: `data`=確定文字 / 2回目: `data`="" 約20ms後）。xterm.js の `CompositionHelper` は `compositionend` ごとに確定テキストを `onData` へ送るため、同じ文字列が 2 回 PTY へ送信されていました。

2つの `onData` はどちらも `compositionend` 後（`isComposing=false`）に発火するため、composition 中を抑制するガードでは防げません。

- ソフトウェアキーボードでは `compositionend` が1回のみ発火するため再現しません（ユーザー報告と一致）。

## 修正

余分な2回目の `compositionend`（空データ かつ 直前から100ms以内）を、xterm の textarea リスナーへ届く前に **capture フェーズ（親要素）で `stopImmediatePropagation()`** し、握りつぶします。

- 確定文字を持つ1回目は必ず通過し、1回だけ送信される
- ソフトウェアキーボード / デスクトップは `compositionend` 1回のみのため影響なし
- IME キャンセル時の空 `compositionend` は直前に確定が無いため抑制されない
- 通常キー（Enter / Escape 等）は `compositionend` を経由しないため無関係

## 動作確認

- iPad + USB 物理キーボードで日本語入力 + Enter → 二重化しないことを実機で確認
- ソフトウェアキーボード / 半角英字 / 通常 Enter が正常なことを確認
- format / lint / type-check 通過

## 補足コミット

`fix: arm64 Docker で pagefind 非対応により make up-prd が失敗する問題を回避` を含みます。Apple Silicon の Docker で pagefind バイナリが未対応のため docs の postbuild が失敗し本番ビルドが起動できない問題の回避で、JP入力修正とは別件です（検索インデックス生成のみ skip、docsページ表示と本番x64ビルドには影響なし）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)