### PR TITLE
fix(terminal): Terminalタブが再接続後にclaudeを起動しないよう永続化

### DIFF
--- a/apps/server/prisma/migrations/20260629000000_add_tab_mode/migration.sql
+++ b/apps/server/prisma/migrations/20260629000000_add_tab_mode/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+-- タブの起動モード（'terminal' | 'claude'）を永続化する。
+-- 既存タブは従来動作（claude自動起動）を維持するため 'claude' を既定値とする。
+ALTER TABLE "tabs" ADD COLUMN "mode" TEXT NOT NULL DEFAULT 'claude';

--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -59,6 +59,7 @@ model Tab {
   taskId       String    @map("task_id")
   order        Int       // タブ表示用の連番
   status       String    // 'idle' | 'running' | 'success' | 'error'
+  mode         String    @default("claude") // 'terminal' | 'claude'
   createdAt    DateTime  @default(now()) @map("created_at")
   startedAt    DateTime  @map("started_at")
   completedAt  DateTime? @map("completed_at")

--- a/apps/server/src/lib/repositories/task.ts
+++ b/apps/server/src/lib/repositories/task.ts
@@ -143,7 +143,7 @@ export async function deleteTask(id: string): Promise<boolean> {
 // ============================================
 
 // タブ作成
-export async function createTab(taskId: string): Promise<Tab | null> {
+export async function createTab(taskId: string, mode: Tab['mode'] = 'claude'): Promise<Tab | null> {
   const task = await prisma.task.findUnique({
     where: { id: taskId },
     include: { tabs: true },
@@ -163,6 +163,7 @@ export async function createTab(taskId: string): Promise<Tab | null> {
       taskId,
       order,
       status: 'idle',
+      mode,
       startedAt: new Date(),
     },
   });
@@ -284,6 +285,7 @@ type PrismaTab = {
   tabId: string;
   order: number;
   status: string;
+  mode: string;
   todos: string | null;
   startedAt: Date;
   completedAt: Date | null;
@@ -317,6 +319,7 @@ function mapTab(tab: PrismaTab): Tab {
     tab_id: tab.tabId,
     order: tab.order,
     status: tab.status as Tab['status'],
+    mode: tab.mode as Tab['mode'],
     todos: tab.todos ? JSON.parse(tab.todos) : [],
     startedAt: tab.startedAt.toISOString(),
     completedAt: tab.completedAt?.toISOString(),

--- a/apps/server/src/routes/tasks.ts
+++ b/apps/server/src/routes/tasks.ts
@@ -423,26 +423,30 @@ export async function tasksRoutes(fastify: FastifyInstance) {
   });
 
   // POST /tasks/:id/tabs
-  fastify.post<{ Params: { id: string } }>('/tasks/:id/tabs', async (request, reply) => {
-    try {
-      const { id: taskId } = request.params;
+  fastify.post<{ Params: { id: string }; Body: { mode?: 'terminal' | 'claude' } }>(
+    '/tasks/:id/tabs',
+    async (request, reply) => {
+      try {
+        const { id: taskId } = request.params;
+        const mode = request.body?.mode === 'terminal' ? 'terminal' : 'claude';
 
-      const task = await taskRepo.getTask(taskId);
-      if (!task) {
-        return reply.status(404).send({ error: 'Task not found' });
-      }
+        const task = await taskRepo.getTask(taskId);
+        if (!task) {
+          return reply.status(404).send({ error: 'Task not found' });
+        }
 
-      const newTab = await taskRepo.createTab(taskId);
-      if (!newTab) {
+        const newTab = await taskRepo.createTab(taskId, mode);
+        if (!newTab) {
+          return reply.status(500).send({ error: 'Failed to create tab' });
+        }
+
+        return reply.status(201).send({ data: { tab: newTab } });
+      } catch (error) {
+        fastify.log.error(error, 'POST /tasks/:id/tabs error');
         return reply.status(500).send({ error: 'Failed to create tab' });
       }
-
-      return reply.status(201).send({ data: { tab: newTab } });
-    } catch (error) {
-      fastify.log.error(error, 'POST /tasks/:id/tabs error');
-      return reply.status(500).send({ error: 'Failed to create tab' });
     }
-  });
+  );
 
   // PUT /tasks/:id/tabs/:tab_id
   fastify.put<{ Params: { id: string; tab_id: string }; Body: TabUpdateBody }>(

--- a/apps/web/src/app/tasks/[id]/page.tsx
+++ b/apps/web/src/app/tasks/[id]/page.tsx
@@ -142,12 +142,14 @@ export default function TaskDetailPage({ params }: TaskDetailPageProps) {
   };
 
   // タブ作成（新規tab_idを返す）
-  const handleTabCreate = async (): Promise<string | undefined> => {
+  const handleTabCreate = async (
+    mode: 'terminal' | 'claude' = 'claude'
+  ): Promise<string | undefined> => {
     try {
       const response = await fetch(apiUrl(`/api/tasks/${id}/tabs`), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({}),
+        body: JSON.stringify({ mode }),
       });
 
       if (!response.ok) throw new Error('Failed to create tab');

--- a/apps/web/src/components/SessionTabs.tsx
+++ b/apps/web/src/components/SessionTabs.tsx
@@ -141,6 +141,17 @@ export function SessionTabs({
     }
   }, [activeTabId, tabs]);
 
+  // Terminalモードのタブには連番ラベル（terminal 1, terminal 2, ...）を割り当てる。
+  // Claude用のステータス表示が存在しないため、番号で識別できるようにする。
+  const terminalNumbers = new Map<string, number>();
+  let terminalCount = 0;
+  for (const tab of tabs) {
+    if (tab.mode === 'terminal') {
+      terminalCount += 1;
+      terminalNumbers.set(tab.tab_id, terminalCount);
+    }
+  }
+
   return (
     <>
       <ConfirmDialog
@@ -188,7 +199,11 @@ export function SessionTabs({
             `}
             >
               <div className="font-medium flex items-center gap-2">
-                <TabStatusIndicator entry={entry} />
+                {tab.mode === 'terminal' ? (
+                  <span className="text-xs">terminal {terminalNumbers.get(tab.tab_id)}</span>
+                ) : (
+                  <TabStatusIndicator entry={entry} />
+                )}
               </div>
               {tabs.length > 1 && (
                 <Button

--- a/apps/web/src/components/TerminalPanel.tsx
+++ b/apps/web/src/components/TerminalPanel.tsx
@@ -22,7 +22,7 @@ interface TerminalPanelProps {
   tabs: Tab[];
   activeTabId?: string;
   onTabChange: (tabId: string) => void;
-  onTabCreate: () => Promise<string | undefined>;
+  onTabCreate: (mode: TabCreateMode) => Promise<string | undefined>;
   onTabDelete: (tabId: string) => void;
   /** Todoリスト更新時のコールバック（タスクカードの Progress Bar 用） */
   onTodosUpdated?: (tabId: string, todos: Todo[]) => void;
@@ -69,9 +69,6 @@ export const TerminalPanel = forwardRef<TerminalPanelHandle, TerminalPanelProps>
     // タブごとのリアルタイムステータス（TerminalViewからの通知）
     const [tabStatusMap, setTabStatusMap] = useState<Map<string, TabStatusEntry>>(new Map());
 
-    // タブごとの起動モード（terminal: claudeなし / claude: claude自動起動）
-    const [tabModeMap, setTabModeMap] = useState<Map<string, TabCreateMode>>(new Map());
-
     // 各TerminalViewへのrefマップ
     const terminalRefs = useRef<Map<string, TerminalViewHandle>>(new Map());
 
@@ -117,16 +114,11 @@ export const TerminalPanel = forwardRef<TerminalPanelHandle, TerminalPanelProps>
 
     const handleTabCreate = useCallback(
       async (mode: TabCreateMode) => {
-        const newTabId = await onTabCreate();
+        const newTabId = await onTabCreate(mode);
         if (newTabId) {
           setMountedTabIds((prev) => {
             const next = new Set(prev);
             next.add(newTabId);
-            return next;
-          });
-          setTabModeMap((prev) => {
-            const next = new Map(prev);
-            next.set(newTabId, mode);
             return next;
           });
         }
@@ -149,11 +141,6 @@ export const TerminalPanel = forwardRef<TerminalPanelHandle, TerminalPanelProps>
           return next;
         });
         setTabStatusMap((prev) => {
-          const next = new Map(prev);
-          next.delete(tabId);
-          return next;
-        });
-        setTabModeMap((prev) => {
           const next = new Map(prev);
           next.delete(tabId);
           return next;
@@ -219,9 +206,9 @@ export const TerminalPanel = forwardRef<TerminalPanelHandle, TerminalPanelProps>
                   cwd={task.worktreePath}
                   worktreePath={task.worktreePath}
                   command={
-                    tabModeMap.get(tab.tab_id) !== 'terminal'
-                      ? `claude --dangerously-skip-permissions --resume ${tab.tab_id} 2>/dev/null || claude --dangerously-skip-permissions --session-id ${tab.tab_id}`
-                      : undefined
+                    tab.mode === 'terminal'
+                      ? undefined
+                      : `claude --dangerously-skip-permissions --resume ${tab.tab_id} 2>/dev/null || claude --dangerously-skip-permissions --session-id ${tab.tab_id}`
                   }
                   className="h-full"
                   initialTodos={tab.todos}

--- a/apps/web/src/components/planner/PlannerPanel.tsx
+++ b/apps/web/src/components/planner/PlannerPanel.tsx
@@ -70,6 +70,7 @@ export function PlannerPanel() {
         tab_id: tabId,
         order: tabs.length,
         status: 'idle',
+        mode,
         startedAt: now,
         updatedAt: now,
       };

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -36,6 +36,7 @@ export interface Tab {
   tab_id: string; // UUID（タブ作成時に生成）
   order: number; // タブ表示用の連番
   status: 'idle' | 'running' | 'waiting' | 'success' | 'error';
+  mode: 'terminal' | 'claude'; // タブの起動モード（terminal: claude自動起動なし）
   todos?: Todo[];
   startedAt: string;
   completedAt?: string;


### PR DESCRIPTION
タブの起動モード（terminal/claude）がメモリ内stateにのみ保持されており、
リロードやPTYのGC後に失われ、Terminalタブでもclaudeが自動起動していた。
Tabモデルにmodeを追加してDBに永続化し、mode='terminal'のタブでは
claude起動コマンドを実行しないよう修正。

Terminalタブはステータス（claude専用）を持たないため、
タブ表示を「terminal N」の連番ラベルに変更。