### PR TITLE
fix(terminal): iPad等タッチデバイスでxtermがスクロールできない不具合を修正

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -273,6 +273,14 @@ select:hover:not(:focus):not(:disabled) {
   border-color: var(--error);
 }
 
+/* iPad等タッチデバイスでxtermのタッチスクロールがページ全体のスクロールに
+   吸われてしまう問題への対処。viewport要素にタッチジェスチャーを委譲させる */
+.xterm-viewport {
+  touch-action: pan-y;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+}
+
 .form-input-error:focus-visible {
   outline: none;
   border-color: var(--error);


### PR DESCRIPTION
.xterm-viewportにtouch-action/overscroll-behaviorが未設定のため、 タッチスクロールがページ全体のスクロールに吸われてしまっていた