### PR TITLE
fix(terminal): タブステータス表示の不具合を修正

### DIFF
--- a/apps/server/src/routes/internal.ts
+++ b/apps/server/src/routes/internal.ts
@@ -74,4 +74,26 @@ export async function internalRoutes(fastify: FastifyInstance) {
       return reply.status(200).send({ ok: true });
     }
   );
+
+  // POST /internal/tabs/:tab_id/interrupt - ESC等によるClaude中断をidleに反映
+  fastify.post<{ Params: { tab_id: string } }>(
+    '/internal/tabs/:tab_id/interrupt',
+    async (request, reply) => {
+      const { tab_id } = request.params;
+
+      const result = await prisma.tab.updateMany({
+        where: { tabId: tab_id },
+        data: { status: 'idle' },
+      });
+
+      if (result.count === 0) {
+        return reply.status(404).send({ error: 'Tab not found' });
+      }
+
+      const room = `tab:${tab_id}`;
+      io.to(room).emit('status-changed', { sessionId: tab_id, status: 'idle' });
+
+      return reply.status(200).send({ data: { tabId: tab_id, status: 'idle' } });
+    }
+  );
 }

--- a/apps/web/src/components/TerminalPanel.tsx
+++ b/apps/web/src/components/TerminalPanel.tsx
@@ -66,8 +66,34 @@ export const TerminalPanel = forwardRef<TerminalPanelHandle, TerminalPanelProps>
       }
     }, [activeTabId]);
 
-    // タブごとのリアルタイムステータス（TerminalViewからの通知）
-    const [tabStatusMap, setTabStatusMap] = useState<Map<string, TabStatusEntry>>(new Map());
+    // タブごとのリアルタイムステータス（TerminalViewからの通知）。
+    // 初期値はDBの tab.status からシードする（ページ再訪時に success 等を維持するため）。
+    const [tabStatusMap, setTabStatusMap] = useState<Map<string, TabStatusEntry>>(
+      () =>
+        new Map(
+          tabs.map((tab) => [
+            tab.tab_id,
+            { terminal: 'connecting', claude: tab.status as ClaudeStatus },
+          ])
+        )
+    );
+
+    // tabs が再フェッチされた場合も未追跡タブをシードする。
+    // 既にリアルタイム値を持つタブは上書きしない（Socket.IO由来の最新状態を優先する）。
+    useEffect(() => {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setTabStatusMap((prev) => {
+        let changed = false;
+        const next = new Map(prev);
+        for (const tab of tabs) {
+          if (!next.has(tab.tab_id)) {
+            next.set(tab.tab_id, { terminal: 'connecting', claude: tab.status as ClaudeStatus });
+            changed = true;
+          }
+        }
+        return changed ? next : prev;
+      });
+    }, [tabs]);
 
     // 各TerminalViewへのrefマップ
     const terminalRefs = useRef<Map<string, TerminalViewHandle>>(new Map());
@@ -212,6 +238,7 @@ export const TerminalPanel = forwardRef<TerminalPanelHandle, TerminalPanelProps>
                   }
                   className="h-full"
                   initialTodos={tab.todos}
+                  initialClaudeStatus={tab.status as ClaudeStatus}
                   onTodosUpdated={onTodosUpdated}
                   onStatusChange={handleStatusChange}
                 />

--- a/apps/web/src/components/TerminalView.tsx
+++ b/apps/web/src/components/TerminalView.tsx
@@ -52,6 +52,8 @@ interface TerminalViewProps {
   className?: string;
   /** DBから読み込んだ初期Todoリスト */
   initialTodos?: Todo[];
+  /** DBから読み込んだ初期Claudeステータス（ページ再訪時にsuccess等を維持するため） */
+  initialClaudeStatus?: ClaudeStatus;
   /** Todoリスト更新時のコールバック（タスクカードの Progress Bar 用） */
   onTodosUpdated?: (tabId: string, todos: Todo[]) => void;
   /** タブがアクティブかどうか（フォーカス制御用） */
@@ -81,6 +83,7 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
     command,
     className = '',
     initialTodos,
+    initialClaudeStatus,
     isActive,
     onTodosUpdated,
     onStatusChange,
@@ -112,7 +115,9 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
   // サーバ側セッションが GC 済みで join に失敗した際の自動再生成回数（無限ループ防止）
   const sessionRecreateRef = useRef(0);
   const [status, setStatus] = useState<TerminalStatus>('idle');
-  const [claudeStatus, setClaudeStatus] = useState<ClaudeStatus>('idle');
+  const [claudeStatus, setClaudeStatus] = useState<ClaudeStatus>(initialClaudeStatus ?? 'idle');
+  // ESC中断検知（term.onData のクロージャから最新値を読むためのref）
+  const claudeStatusRef = useRef<ClaudeStatus>(initialClaudeStatus ?? 'idle');
   const [todos, setTodos] = useState<Todo[]>(initialTodos ?? []);
   const [copied, setCopied] = useState(false);
   const { effectiveTheme } = useTheme();
@@ -147,6 +152,10 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
 
   useLayoutEffect(() => {
     statusRef.current = status;
+  });
+
+  useLayoutEffect(() => {
+    claudeStatusRef.current = claudeStatus;
   });
 
   // アクティブになったタイミングで xterm にフォーカスを当てる
@@ -433,6 +442,18 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
     };
   }, []);
 
+  /**
+   * ESC中断をサーバに通知する。Claude CLIはESC中断時にStop/SessionEndを発火しないため、
+   * クライアント側でESC押下を検知してtab.statusをidleに戻す。
+   */
+  async function notifyInterrupt(sessionId: string) {
+    try {
+      await fetch(apiUrl(`/api/internal/tabs/${sessionId}/interrupt`), { method: 'POST' });
+    } catch (err) {
+      console.warn('[TerminalView] Failed to notify interrupt:', err);
+    }
+  }
+
   function sendResize() {
     const socket = socketRef.current;
     const term = termRef.current;
@@ -641,6 +662,15 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(fu
     );
 
     onDataDisposeRef.current = term.onData((data) => {
+      // ESC単体（矢印キー等のエスケープシーケンスは複数バイトのため対象外）押下時、
+      // running/waiting中ならClaude中断とみなしサーバへ通知する
+      if (
+        data === '\x1b' &&
+        (claudeStatusRef.current === 'running' || claudeStatusRef.current === 'waiting') &&
+        sessionIdRef.current
+      ) {
+        void notifyInterrupt(sessionIdRef.current);
+      }
       if (socket.connected && sessionIdRef.current) {
         socket.emit('input', { sessionId: sessionIdRef.current, data });
       }


### PR DESCRIPTION
ESC中断時にrunningのまま固着する問題と、successタブをページ再訪すると
idleに戻ってしまう問題を修正。

- ESC押下でrunning/waiting中ならサーバに中断を通知しidleへ更新
- TerminalPanelでtabStatusMapをDBのtab.statusからシードし、再訪時も success/error等の表示を維持