### PR TITLE
fix(cli): @fastify/multipart を apps/cli の依存に追加

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -61,6 +61,7 @@
   "dependencies": {
     "@fastify/cors": "^11.2.0",
     "@fastify/http-proxy": "^11.5.0",
+    "@fastify/multipart": "^10.1.0",
     "dotenv": "^17.2.3",
     "@libsql/client": "0.8.1",
     "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
       "dependencies": {
         "@fastify/cors": "^11.2.0",
         "@fastify/http-proxy": "^11.5.0",
+        "@fastify/multipart": "^10.1.0",
         "@libsql/client": "0.8.1",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@prisma/adapter-libsql": "^7.3.0",


### PR DESCRIPTION
voice-input機能でapps/server側にのみ追加され、apps/cli/package.jsonへの 反映漏れによりグローバルインストール時にERR_MODULE_NOT_FOUNDが発生していた。