### PR TITLE
fix(terminal): claude logout後のオンボーディング再表示を防ぐ

### DIFF
--- a/apps/server/src/lib/claude-config-guard.ts
+++ b/apps/server/src/lib/claude-config-guard.ts
@@ -1,0 +1,46 @@
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+/**
+ * `claude logout` は ~/.claude.json の hasCompletedOnboarding を含む
+ * first-launch setup state をリセットする。Tsunagi は全タブ/タスクの
+ * claude プロセスが同一 HOME（同一 ~/.claude.json）を共有しているため、
+ * どこか1セッションで logout すると以降全タブでオンボーディングウィザード
+ * （対話UIではなく初回セットアップ画面）が起動してしまい、--resume/--session-id
+ * を前提にした自動起動フローが止まる。claude 起動直前にこのフラグだけ補正する。
+ */
+export async function ensureClaudeOnboardingCompleted(): Promise<void> {
+  const configPath = path.join(os.homedir(), '.claude.json');
+
+  let raw: string;
+  try {
+    raw = await fs.readFile(configPath, 'utf-8');
+  } catch {
+    // 初回起動などファイルが存在しない場合は何もしない
+    return;
+  }
+
+  let config: Record<string, unknown>;
+  try {
+    config = JSON.parse(raw);
+  } catch {
+    return;
+  }
+
+  if (config.hasCompletedOnboarding === true) {
+    return;
+  }
+
+  config.hasCompletedOnboarding = true;
+
+  // 他の claude プロセスによる同時書き込みと衝突しても部分書き込みにならないよう
+  // tmpファイルに書いてから rename する。
+  const tmpPath = `${configPath}.tsunagi-tmp-${process.pid}`;
+  try {
+    await fs.writeFile(tmpPath, JSON.stringify(config), 'utf-8');
+    await fs.rename(tmpPath, configPath);
+  } catch {
+    await fs.rm(tmpPath, { force: true }).catch(() => {});
+  }
+}

--- a/apps/server/src/routes/terminal.ts
+++ b/apps/server/src/routes/terminal.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 import { ptyManager } from '../pty-manager.js';
 import { prisma } from '../lib/db.js';
 import { getEnv } from '../lib/repositories/environment.js';
+import { ensureClaudeOnboardingCompleted } from '../lib/claude-config-guard.js';
 
 // サーバーはプロジェクトルートから起動されるため process.cwd() でルートを取得
 const TSUNAGI_EDITOR_PATH = path.resolve(process.cwd(), 'scripts/monaco-editor.sh');
@@ -287,6 +288,10 @@ export async function terminalRoutes(fastify: FastifyInstance) {
       // コマンドが指定されていればPTY起動後にシェルへ書き込む
       if (command) {
         const cmd = command.endsWith('\n') ? command : command + '\n';
+        // claude logout で ~/.claude.json の hasCompletedOnboarding がリセットされて
+        // いると、次回 claude 起動時にオンボーディングウィザードが表示され --resume/
+        // --session-id を前提にした自動起動フローが止まるため、起動前に補正する。
+        await ensureClaudeOnboardingCompleted();
         // シェルの初期化（プロンプト表示）を待つため少し遅延させて書き込む
         setTimeout(() => {
           session.pty.write(cmd);


### PR DESCRIPTION
claude logout は ~/.claude.json の hasCompletedOnboarding を含む first-launch setup state をリセットする。Tsunagi は全タブ/タスクの claude プロセスが同一 HOME を共有しているため、どこか1セッションで
logout すると以降全タブでオンボーディングウィザードが表示され、
--resume/--session-id 前提の自動起動フローが止まっていた。
claude 起動直前に hasCompletedOnboarding を補正するガードを追加。