### PR TITLE
fix(web): 狭幅画面でタスク一覧をオーバーレイ表示に切り替え

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -9,6 +9,7 @@ import { TaskDialog } from '@/components/TaskDialog';
 import { CloneRepositoryDialog } from '@/components/CloneRepositoryDialog';
 import { BatchDeleteDialog } from '@/components/BatchDeleteDialog';
 import { TaskListPanel } from '@/components/planner/TaskListPanel';
+import { TaskListOverlay } from '@/components/planner/TaskListOverlay';
 import { PlannerPanel } from '@/components/planner/PlannerPanel';
 import { type FilterState } from '@/components/planner/FilterBar';
 import { useBatchDelete } from '@/hooks/useBatchDelete';
@@ -64,6 +65,7 @@ export default function Home() {
   // Resizable panel
   const [leftPanelWidth, setLeftPanelWidth] = useState(380);
   const [isResizing, setIsResizing] = useState(false);
+  const [isTaskListOverlayOpen, setIsTaskListOverlayOpen] = useState(false);
 
   // 初回ユーザーフローの状態を検出
   const onboardingState = useMemo(() => {
@@ -372,6 +374,7 @@ export default function Home() {
         onCloneClick={() => setIsCloneDialogOpen(true)}
         onSettingsClick={() => router.push('/settings')}
         onReload={loadData}
+        onTaskListClick={() => setIsTaskListOverlayOpen(true)}
         nextStep={onboardingState.nextStep}
         isCloneDialogOpen={isCloneDialogOpen}
       />
@@ -440,6 +443,22 @@ export default function Home() {
         onClose={() => setIsBatchDeleteDialogOpen(false)}
         onConfirm={handleBatchDelete}
       />
+
+      {/* Task list overlay (narrow screens only) */}
+      <TaskListOverlay open={isTaskListOverlayOpen} onOpenChange={setIsTaskListOverlayOpen}>
+        <TaskListPanel
+          tasks={filteredTasks}
+          repositories={repositories}
+          filters={filterState}
+          onFilterChange={setFilterState}
+          onReorder={handleReorder}
+          onAddTask={() => {
+            setIsTaskListOverlayOpen(false);
+            setIsAddTaskDialogOpen(true);
+          }}
+          tabTodosMap={tabTodosMap}
+        />
+      </TaskListOverlay>
     </div>
   );
 }

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Settings, RefreshCw, FolderDown } from 'lucide-react';
+import { Settings, RefreshCw, FolderDown, PanelLeft } from 'lucide-react';
 import Image from 'next/image';
 import { ThemeToggle } from './ThemeToggle';
 import { Button } from '@/components/ui/button';
@@ -10,6 +10,7 @@ interface HeaderProps {
   onCloneClick: () => void;
   onSettingsClick: () => void;
   onReload: () => void;
+  onTaskListClick?: () => void;
   nextStep?: 'clone' | 'env' | 'task' | 'complete';
   isCloneDialogOpen?: boolean;
 }
@@ -18,6 +19,7 @@ export function Header({
   onCloneClick,
   onSettingsClick,
   onReload,
+  onTaskListClick,
   nextStep = 'complete',
   isCloneDialogOpen = false,
 }: HeaderProps) {
@@ -34,6 +36,19 @@ export function Header({
       <h1 className="flex-shrink-0 flex items-center">
         <Image src={logoIcon} alt="Tsunagi" width={32} height={32} priority />
       </h1>
+
+      {/* Task list toggle (narrow screens only) */}
+      {onTaskListClick && (
+        <Button
+          variant="outline"
+          size="icon-lg"
+          onClick={onTaskListClick}
+          className="lg:hidden active:scale-95"
+          title="Task List"
+        >
+          <PanelLeft />
+        </Button>
+      )}
 
       {/* Spacer */}
       <div className="flex-1" />

--- a/apps/web/src/components/planner/TaskListOverlay.tsx
+++ b/apps/web/src/components/planner/TaskListOverlay.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { Dialog as DialogPrimitive } from '@base-ui/react/dialog';
+import { X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+interface TaskListOverlayProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: ReactNode;
+}
+
+export function TaskListOverlay({ open, onOpenChange, children }: TaskListOverlayProps) {
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange} modal>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Backdrop
+          className={cn(
+            'fixed inset-0 z-50 bg-black/20 backdrop-blur-sm',
+            'data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0'
+          )}
+        />
+        <DialogPrimitive.Popup
+          className={cn(
+            'fixed inset-y-0 left-0 z-50 flex h-full w-[85vw] max-w-sm flex-col',
+            'bg-background border-r border-border shadow-lg outline-none',
+            'data-open:animate-in data-open:slide-in-from-left data-closed:animate-out data-closed:slide-out-to-left'
+          )}
+        >
+          <div className="flex h-14 flex-shrink-0 items-center justify-between border-b border-border px-4">
+            <DialogPrimitive.Title className="text-sm font-medium text-foreground">
+              Tasks
+            </DialogPrimitive.Title>
+            <DialogPrimitive.Close
+              render={
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="text-muted-foreground hover:text-foreground"
+                />
+              }
+            >
+              <X className="size-4" />
+              <span className="sr-only">Close</span>
+            </DialogPrimitive.Close>
+          </div>
+          <div className="min-h-0 flex-1">{children}</div>
+        </DialogPrimitive.Popup>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}


### PR DESCRIPTION
lg未満(<1024px)ではタスク一覧サイドバーがhidden lg:flexで完全に非表示になり、 到達手段が無かったため、Headerのトグルボタンから左スライドオーバーレイで
開閉できるようにした。PC版(lg以上)の表示は変更なし。