### PR TITLE
fix(voice): LLM整形のシステムプロンプトを設定可能にし、同音異義語の誤変換に対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ apps/server/src/generated/
 .venv/
 __pycache__/
 *.pyc
+
+# 音声入力のwhisper生テキスト/LLM整形結果デバッグログ(voice-debug-log.ts)
+apps/server/logs/

--- a/apps/server/src/lib/voice-debug-log.ts
+++ b/apps/server/src/lib/voice-debug-log.ts
@@ -1,0 +1,40 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// apps/server直下(src/libとdist/libのどちらから見ても2階層上)に置く。
+// docker-compose(compose.yml)ではリポジトリ全体がbind mountされているため、
+// ホスト側からもこのファイルをそのまま読める(named volumeの~/.tsunagiとは違い、
+// Claude Codeが次回セッションでRead/grepしてプロンプト改善の材料にできる)。
+const LOG_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..', 'logs');
+const LOG_FILE = path.join(LOG_DIR, 'voice-input-debug.log');
+
+// デバッグ用途のため肥大化を防ぐ簡易ローテーション(直近件数のみ保持)。
+const MAX_ENTRIES = 200;
+
+export interface VoiceDebugLogEntry {
+  whisperPrompt: string | undefined;
+  whisperText: string;
+  useLlm: boolean;
+  llmSystemPrompt?: string;
+  correctedText?: string;
+  llmError?: string;
+}
+
+// Whisper生テキストとLLM整形結果を1リクエスト1行(JSON Lines)で追記する。
+// プロンプト改善のデバッグ専用ログであり、書き込み失敗はリクエスト自体を
+// 失敗させるべきではないため例外を握りつぶす。
+export function appendVoiceDebugLog(entry: VoiceDebugLogEntry): void {
+  try {
+    fs.mkdirSync(LOG_DIR, { recursive: true });
+    const line = JSON.stringify({ timestamp: new Date().toISOString(), ...entry });
+    fs.appendFileSync(LOG_FILE, `${line}\n`);
+
+    const lines = fs.readFileSync(LOG_FILE, 'utf-8').split('\n').filter(Boolean);
+    if (lines.length > MAX_ENTRIES) {
+      fs.writeFileSync(LOG_FILE, `${lines.slice(-MAX_ENTRIES).join('\n')}\n`);
+    }
+  } catch {
+    // デバッグログの書き込み失敗は無視する(本処理に影響させない)。
+  }
+}

--- a/apps/server/src/routes/whisper.ts
+++ b/apps/server/src/routes/whisper.ts
@@ -5,16 +5,19 @@ import {
   stopWhisperServer,
 } from '../lib/whisper-process.js';
 import { generateLlmCompletion } from '../lib/llm-process.js';
+import { appendVoiceDebugLog } from '../lib/voice-debug-log.js';
 
 // ユーザーが依存関係(pipパッケージ)をセットアップ済みのローカル常駐サーバー
 // (apps/whisper-server)を指す。依存関係のインストール自体はtsunagi側では行わず、
 // プロセスの起動・停止のみ管理する。
 const WHISPER_SERVER_URL = process.env.TSUNAGI_WHISPER_SERVER_URL || 'http://127.0.0.1:8765';
 
-// 文字起こし結果のLLM整形に使うシステムプロンプト。検証で
-// 「原文の言葉遣いを維持しつつ句読点・誤字だけ直す」設定が有効と確認できたもの。
-const TRANSCRIPTION_CORRECTION_SYSTEM_PROMPT =
-  '以下は音声認識による文字起こし結果です。元の言葉遣いや言い回し、文章構成はできるだけそのまま維持してください。行ってよいのは句読点の追加と、明らかな誤字(音声認識の誤変換)の修正のみです。要約・言い換え・フィラーの除去・文の並び替えなどは行わないでください。修正後の文章のみを出力し、前置きや説明は不要です。';
+// 文字起こし結果のLLM整形に使うシステムプロンプト(既定値)。Settings画面で
+// 上書きされなかった場合に使う。同音異義語の誤変換(例:「句読点」→「句頭点」、
+// 「誤字」→「語字」)を放置してしまう問題があったため、該当パターンを明示して
+// 一語ずつ文脈と照合するよう指示している。
+const DEFAULT_TRANSCRIPTION_CORRECTION_SYSTEM_PROMPT =
+  '以下は音声認識(Whisper)による文字起こし結果です。元の言葉遣いや言い回し、文章構成はできるだけそのまま維持してください。行ってよいのは次の2つだけです。(1)句読点の追加。(2)音声認識特有の誤字の修正。日本語の音声認識では、発音が同じで意味の異なる漢字に変換されることがよくあります(例:「句読点」→「句頭点」、「誤字」→「語字」など)。一見すると自然な単語に見えても文脈に合わない場合は誤変換である可能性が高いため、一語ずつ文脈に合っているか確認し、明らかな誤りは正しい漢字に修正してください。要約・言い換え・フィラーの除去・文の並び替えなど、上記2つ以外の変更は行わないでください。修正後の文章のみを出力し、前置きや説明は不要です。';
 
 export async function whisperRoutes(fastify: FastifyInstance) {
   // GET /whisper/server/status
@@ -56,6 +59,14 @@ export async function whisperRoutes(fastify: FastifyInstance) {
     const useLlmField = file.fields.useLlm as { value?: unknown } | undefined;
     const useLlm = useLlmField?.value === 'true';
 
+    // LLM整形用システムプロンプトもSettings画面で編集・保存でき、指定があれば
+    // 既定のプロンプトの代わりに使う(空文字列の場合は既定のプロンプトを使う)。
+    const systemPromptField = file.fields.systemPrompt as { value?: unknown } | undefined;
+    const systemPrompt =
+      typeof systemPromptField?.value === 'string' && systemPromptField.value.trim()
+        ? systemPromptField.value
+        : DEFAULT_TRANSCRIPTION_CORRECTION_SYSTEM_PROMPT;
+
     const buffer = await file.toBuffer();
     const body = new FormData();
     body.append('file', new Blob([buffer]), file.filename);
@@ -85,6 +96,7 @@ export async function whisperRoutes(fastify: FastifyInstance) {
     }
 
     if (!useLlm || !whisperText) {
+      appendVoiceDebugLog({ whisperPrompt: prompt, whisperText, useLlm });
       return reply.status(200).send({ text: whisperText });
     }
 
@@ -94,14 +106,29 @@ export async function whisperRoutes(fastify: FastifyInstance) {
     try {
       const corrected = await generateLlmCompletion(
         [
-          { role: 'system', content: TRANSCRIPTION_CORRECTION_SYSTEM_PROMPT },
+          { role: 'system', content: systemPrompt },
           { role: 'user', content: whisperText },
         ],
         Math.min(4096, Math.max(512, whisperText.length * 4))
       );
-      return reply.status(200).send({ text: corrected.trim() });
+      const correctedText = corrected.trim();
+      appendVoiceDebugLog({
+        whisperPrompt: prompt,
+        whisperText,
+        useLlm,
+        llmSystemPrompt: systemPrompt,
+        correctedText,
+      });
+      return reply.status(200).send({ text: correctedText });
     } catch (error) {
       fastify.log.error(error, 'LLM correction failed, falling back to raw transcription');
+      appendVoiceDebugLog({
+        whisperPrompt: prompt,
+        whisperText,
+        useLlm,
+        llmSystemPrompt: systemPrompt,
+        llmError: error instanceof Error ? error.message : String(error),
+      });
       return reply.status(200).send({
         text: whisperText,
         warning: 'ローカルLLMによる整形に失敗したため、文字起こし結果をそのまま使用しました',

--- a/apps/web/src/components/VoiceInputButton.tsx
+++ b/apps/web/src/components/VoiceInputButton.tsx
@@ -14,6 +14,8 @@ const AUDIO_BITS_PER_SECOND = 128_000;
 const STORAGE_KEY = 'tsunagi:voice-input-enabled';
 // Settings画面で編集できる、whisperのinitial_prompt(表記ゆれ・句読点等のヒント)。
 export const WHISPER_PROMPT_STORAGE_KEY = 'tsunagi:whisper-prompt';
+// Settings画面で編集できる、LLM整形時のシステムプロンプト(空ならサーバー側の既定値を使う)。
+export const LLM_SYSTEM_PROMPT_STORAGE_KEY = 'tsunagi:llm-system-prompt';
 // whisper-serverの起動状態を軽くポーリングし、未起動時はボタンを無効化する。
 const SERVER_STATUS_POLL_MS = 5000;
 
@@ -153,6 +155,8 @@ export function VoiceInputButton({ onTranscribed }: VoiceInputButtonProps) {
         if (prompt) formData.append('prompt', prompt);
         const useLlm = localStorage.getItem(LOCAL_LLM_ENABLED_STORAGE_KEY) === 'true';
         formData.append('useLlm', String(useLlm));
+        const systemPrompt = localStorage.getItem(LLM_SYSTEM_PROMPT_STORAGE_KEY);
+        if (systemPrompt) formData.append('systemPrompt', systemPrompt);
         formData.append('file', blob, 'recording.webm');
 
         const response = await fetch(apiUrl('/api/whisper/transcribe'), {

--- a/apps/web/src/components/settings/LocalLlmSection.tsx
+++ b/apps/web/src/components/settings/LocalLlmSection.tsx
@@ -6,8 +6,10 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Dialog } from '@/components/ui/Dialog';
 import { Progress } from '@/components/ui/progress';
+import { Textarea } from '@/components/ui/textarea';
 import { apiUrl } from '@/lib/api-url';
 import { toaster } from '@/lib/toaster';
+import { LLM_SYSTEM_PROMPT_STORAGE_KEY } from '@/components/VoiceInputButton';
 
 const STORAGE_KEY = 'tsunagi:local-llm-enabled';
 // 音声入力(VoiceInputButton)から、文字起こし結果をLLMで整形するかどうかの
@@ -67,11 +69,17 @@ export function LocalLlmSection() {
   const [enabled, setEnabledState] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
   const [serverInfo, setServerInfo] = useState<ServerInfo | null>(null);
+  const [systemPrompt, setSystemPrompt] = useState('');
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const setEnabled = useCallback((next: boolean) => {
     setEnabledState(next);
     localStorage.setItem(STORAGE_KEY, String(next));
+  }, []);
+
+  const handleSystemPromptChange = useCallback((next: string) => {
+    setSystemPrompt(next);
+    localStorage.setItem(LLM_SYSTEM_PROMPT_STORAGE_KEY, next);
   }, []);
 
   const fetchStatus = useCallback(async (): Promise<ServerInfo> => {
@@ -83,6 +91,7 @@ export function LocalLlmSection() {
 
   useEffect(() => {
     setEnabledState(localStorage.getItem(STORAGE_KEY) === 'true');
+    setSystemPrompt(localStorage.getItem(LLM_SYSTEM_PROMPT_STORAGE_KEY) ?? '');
     void fetchStatus();
   }, [fetchStatus]);
 
@@ -196,38 +205,54 @@ export function LocalLlmSection() {
             ローカルLLMを有効化する
           </Button>
         ) : (
-          <div className="flex flex-wrap items-center gap-2">
-            {!serverKnown ? (
-              <span className="flex items-center gap-2 text-muted-foreground">
-                <Loader2 className="size-4 animate-spin" />
-                状態を確認中...
-              </span>
-            ) : serverReady ? (
-              <span className="flex items-center gap-2 text-success">
-                <CheckCircle2 className="size-4" />
-                ローカルLLM: 有効
-              </span>
-            ) : (
-              <span className="flex items-center gap-2 text-warning">
-                <AlertCircle className="size-4" />
-                ローカルLLM: 有効化済み（サーバー停止中）
-              </span>
-            )}
-            {serverInfo && (
-              <span className="text-xs/relaxed text-muted-foreground">
-                ({STEP_LABEL[serverInfo.step]})
-              </span>
-            )}
-            {serverKnown && !serverReady && (
-              <Button size="default" onClick={openModal}>
-                <Bot />
-                サーバーを起動
+          <>
+            <div className="flex flex-wrap items-center gap-2">
+              {!serverKnown ? (
+                <span className="flex items-center gap-2 text-muted-foreground">
+                  <Loader2 className="size-4 animate-spin" />
+                  状態を確認中...
+                </span>
+              ) : serverReady ? (
+                <span className="flex items-center gap-2 text-success">
+                  <CheckCircle2 className="size-4" />
+                  ローカルLLM: 有効
+                </span>
+              ) : (
+                <span className="flex items-center gap-2 text-warning">
+                  <AlertCircle className="size-4" />
+                  ローカルLLM: 有効化済み（サーバー停止中）
+                </span>
+              )}
+              {serverInfo && (
+                <span className="text-xs/relaxed text-muted-foreground">
+                  ({STEP_LABEL[serverInfo.step]})
+                </span>
+              )}
+              {serverKnown && !serverReady && (
+                <Button size="default" onClick={openModal}>
+                  <Bot />
+                  サーバーを起動
+                </Button>
+              )}
+              <Button size="default" variant="outline" onClick={handleDisable}>
+                無効にする
               </Button>
-            )}
-            <Button size="default" variant="outline" onClick={handleDisable}>
-              無効にする
-            </Button>
-          </div>
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                整形システムプロンプト (任意)
+              </label>
+              <Textarea
+                value={systemPrompt}
+                onChange={(e) => handleSystemPromptChange(e.target.value)}
+                placeholder="例: 句読点の追加と誤字修正のみ行い、言い回しは変えないでください。"
+                className="min-h-16 text-xs"
+              />
+              <p className="mt-1 text-[0.65rem] text-muted-foreground">
+                文字起こし結果をLLMで整形する際の指示です。空欄の場合は既定のプロンプト(句読点の追加・誤字修正のみを行う指示)を使用します。
+              </p>
+            </div>
+          </>
         )}
       </CardContent>
 

--- a/apps/web/src/components/settings/VoiceInputSection.tsx
+++ b/apps/web/src/components/settings/VoiceInputSection.tsx
@@ -239,11 +239,12 @@ export function VoiceInputSection() {
               <Textarea
                 value={prompt}
                 onChange={(e) => handlePromptChange(e.target.value)}
-                placeholder="例: 句読点を適切に打ってください。固有名詞は正確に表記してください。"
+                placeholder="例: 誤字、句読点、音声入力、Whisper、固有名詞や専門用語など"
                 className="min-h-16 text-xs"
               />
               <p className="mt-1 text-[0.65rem] text-muted-foreground">
-                Whisperの文字起こしスタイル(表記ゆれ・句読点・固有名詞など)を誘導するヒントです。空でも構いません。
+                よく使う単語(固有名詞・専門用語・同音異義語で誤変換されやすい単語など)を列挙すると、
+                Whisperがその表記を優先しやすくなり誤変換が減ります。文章でなく単語の羅列でも構いません。空でも可。
               </p>
             </div>
           </>


### PR DESCRIPTION
LLM整形が「句読点→句頭点」「誤字→語字」のような同音異義語の誤変換を直せて
いなかったため、既定のシステムプロンプトに具体例を追加。また、Whisperの
文字起こしプロンプトと同様にSettings画面からLLMのシステムプロンプトを
編集・保存できるようにした。

あわせて、Whisper生テキストとLLM整形結果をデバッグ用にログ出力する仕組みを
追加し(apps/server/logs/、gitignore対象)、Whisperのプロンプトのヒント文言を 「よく使う単語を列挙すると誤変換が減る」という語彙ヒントとしての説明に更新。