### PR TITLE
fix(voice): whisper-server起動失敗をPython 3.9環境向けに修正し即時検知できるようにする

### DIFF
--- a/apps/server/src/lib/llm-process.ts
+++ b/apps/server/src/lib/llm-process.ts
@@ -28,6 +28,15 @@ const MODEL_CACHE_DIR = path.join(
 // 実測値(2026-07時点、4bit量子化された重み一式の合計)。多少の変動はあるがETA計算の目安として使う。
 const EXPECTED_MODEL_BYTES = 17_200_000_000;
 
+// starting_serverフェーズ(spawn後にhealthyになるまで待つ時間)の上限。
+// mlx_lm.serverは/healthをモデル本体のロード完了を待たずに返す(ロードはバックグラウンド
+// スレッドで進む)ため、この待ち時間の大半はPython起動/import初期化のばらつきに対する
+// マージン。whisperより依存関係が重いぶん長めの90秒を維持する。
+// プロセスが起動途中でクラッシュした場合はこのタイムアウトを待たず即座に検知する。
+const STARTUP_TIMEOUT_MS = 90_000;
+// クラッシュ時にエラーメッセージへ含めるstderrの上限文字数。
+const STDERR_TAIL_MAX_CHARS = 4000;
+
 // このファイルは apps/server/src/lib (dev) または apps/cli/dist/server/lib
 // (npm配布物) のいずれかにいる。どちらの場合も3階層上に llm-server が
 // 兄弟ディレクトリとして存在するようレイアウトを揃えている
@@ -194,24 +203,35 @@ async function runSetupAndStart(dir: string): Promise<void> {
   const child = spawn(
     venvPython(),
     ['-m', 'mlx_lm.server', '--model', MODEL, '--host', '127.0.0.1', '--port', String(LLM_PORT)],
-    { cwd: dir, stdio: 'ignore', env: hfEnv }
+    { cwd: dir, stdio: ['ignore', 'ignore', 'pipe'], env: hfEnv }
   );
-  child.on('exit', () => {
+  let stderrTail = '';
+  child.stderr?.on('data', (chunk: Buffer) => {
+    stderrTail = (stderrTail + chunk.toString()).slice(-STDERR_TAIL_MAX_CHARS);
+  });
+  // healthポーリングとは別に、プロセスが起動途中で終了したことをタイムアウトを待たず検知する。
+  let exitInfo: string | null = null;
+  child.on('exit', (code, signal) => {
+    exitInfo = `exit code=${code} signal=${signal}`;
     if (managedProcess === child) managedProcess = null;
   });
-  child.on('error', () => {
+  child.on('error', (err) => {
+    exitInfo = `spawn error: ${err.message}`;
     if (managedProcess === child) managedProcess = null;
   });
   managedProcess = child;
 
-  // MoEで実計算はアクティブパラメータ(~3B)分のみだが、4bit量子化でも~17GBの
-  // 重みファイル自体はメモリへ展開する必要があるため、whisperより長めに待つ。
   const start = Date.now();
-  while (Date.now() - start < 90000) {
+  while (Date.now() - start < STARTUP_TIMEOUT_MS) {
+    if (exitInfo) {
+      throw new Error(
+        `llm-server crashed while starting (${exitInfo})${stderrTail ? `\n${stderrTail}` : ''}`
+      );
+    }
     if (await checkHealth()) return;
     await sleep(1000);
   }
-  throw new Error('Server did not become healthy within 90s of starting');
+  throw new Error(`Server did not become healthy within ${STARTUP_TIMEOUT_MS / 1000}s of starting`);
 }
 
 export function startLlmServer(): { started: boolean; error?: string } {

--- a/apps/server/src/lib/whisper-process.ts
+++ b/apps/server/src/lib/whisper-process.ts
@@ -22,6 +22,13 @@ const MODEL_CACHE_DIR = path.join(
 // 実測値(2026-07時点、encoder+decoder等の合計)。多少の変動はあるがETA計算の目安として使う。
 const EXPECTED_MODEL_BYTES = 1_614_000_000;
 
+// starting_serverフェーズ(spawn後にhealthyになるまで待つ時間)の上限。
+// 遅いマシンでのPython起動/import/Metal初期化のばらつきを吸収するため60秒に設定。
+// プロセスが起動途中でクラッシュした場合はこのタイムアウトを待たず即座に検知する。
+const STARTUP_TIMEOUT_MS = 60_000;
+// クラッシュ時にエラーメッセージへ含めるstderrの上限文字数。
+const STDERR_TAIL_MAX_CHARS = 4000;
+
 // このファイルは apps/server/src/lib (dev) または apps/cli/dist/server/lib
 // (npm配布物) のいずれかにいる。どちらの場合も3階層上に whisper-server が
 // 兄弟ディレクトリとして存在するようレイアウトを揃えている
@@ -188,22 +195,35 @@ async function runSetupAndStart(dir: string): Promise<void> {
   const child = spawn(
     venvPython(),
     ['-m', 'uvicorn', 'server:app', '--host', '127.0.0.1', '--port', '8765'],
-    { cwd: dir, stdio: 'ignore', env: hfEnv }
+    { cwd: dir, stdio: ['ignore', 'ignore', 'pipe'], env: hfEnv }
   );
-  child.on('exit', () => {
+  let stderrTail = '';
+  child.stderr?.on('data', (chunk: Buffer) => {
+    stderrTail = (stderrTail + chunk.toString()).slice(-STDERR_TAIL_MAX_CHARS);
+  });
+  // healthポーリングとは別に、プロセスが起動途中で終了したことをタイムアウトを待たず検知する。
+  let exitInfo: string | null = null;
+  child.on('exit', (code, signal) => {
+    exitInfo = `exit code=${code} signal=${signal}`;
     if (managedProcess === child) managedProcess = null;
   });
-  child.on('error', () => {
+  child.on('error', (err) => {
+    exitInfo = `spawn error: ${err.message}`;
     if (managedProcess === child) managedProcess = null;
   });
   managedProcess = child;
 
   const start = Date.now();
-  while (Date.now() - start < 30000) {
+  while (Date.now() - start < STARTUP_TIMEOUT_MS) {
+    if (exitInfo) {
+      throw new Error(
+        `whisper-server crashed while starting (${exitInfo})${stderrTail ? `\n${stderrTail}` : ''}`
+      );
+    }
     if (await checkHealth()) return;
     await sleep(1000);
   }
-  throw new Error('Server did not become healthy within 30s of starting');
+  throw new Error(`Server did not become healthy within ${STARTUP_TIMEOUT_MS / 1000}s of starting`);
 }
 
 export function startWhisperServer(): { started: boolean; error?: string } {

--- a/apps/whisper-server/server.py
+++ b/apps/whisper-server/server.py
@@ -11,6 +11,7 @@
 """
 
 import io
+from typing import Optional
 
 import av
 import numpy as np
@@ -49,7 +50,7 @@ def decode_to_16k_mono(data: bytes) -> np.ndarray:
 
 
 @app.post("/transcribe")
-async def transcribe(file: UploadFile = File(...), prompt: str | None = Form(None)) -> dict:
+async def transcribe(file: UploadFile = File(...), prompt: Optional[str] = Form(None)) -> dict:
     data = await file.read()
     audio = decode_to_16k_mono(data)
     # initial_promptは文字起こしのスタイル(表記ゆれ・句読点・固有名詞など)を


### PR DESCRIPTION
server.pyのstr | None構文はPython 3.10未満のFastAPI環境ではルート登録時に TypeErrorでクラッシュする。typing.Optionalへ変更しPython 3.9でも動くようにした。

あわせてwhisper/llmサーバーの起動ポーリングを改修し、プロセスが起動途中で
クラッシュした場合はタイムアウトを待たずstderr付きで即座に検知できるように
した。これによりwhisperの起動タイムアウトを30秒から60秒に延長しても、
クラッシュ時の待ち時間が伸びる心配がなくなる。