### PR TITLE
fix(voice): モデルDLの残り時間表示が再計算のたびに計算中に戻る問題を修正

### DIFF
--- a/apps/server/src/lib/llm-process.ts
+++ b/apps/server/src/lib/llm-process.ts
@@ -149,7 +149,12 @@ async function trackModelDownload(child: ChildProcess): Promise<void> {
     const elapsedSec = (now - lastTime) / 1000;
     const bytesPerSec = elapsedSec > 0 ? (downloaded - lastBytes) / elapsedSec : 0;
     const remaining = EXPECTED_MODEL_BYTES - downloaded;
-    const etaSeconds = bytesPerSec > 0 ? Math.max(0, Math.round(remaining / bytesPerSec)) : null;
+    // 転送が一時的に止まって見える(ポーリング間隔とディスク書き込みのタイミングがずれる)だけで
+    // 速度0になることがあるため、その場合は直前のETAを維持し「計算中...」への逆戻りを防ぐ。
+    const etaSeconds =
+      bytesPerSec > 0
+        ? Math.max(0, Math.round(remaining / bytesPerSec))
+        : (downloadProgress?.etaSeconds ?? null);
 
     downloadProgress = {
       downloadedBytes: downloaded,

--- a/apps/server/src/lib/whisper-process.ts
+++ b/apps/server/src/lib/whisper-process.ts
@@ -143,7 +143,12 @@ async function trackModelDownload(child: ChildProcess): Promise<void> {
     const elapsedSec = (now - lastTime) / 1000;
     const bytesPerSec = elapsedSec > 0 ? (downloaded - lastBytes) / elapsedSec : 0;
     const remaining = EXPECTED_MODEL_BYTES - downloaded;
-    const etaSeconds = bytesPerSec > 0 ? Math.max(0, Math.round(remaining / bytesPerSec)) : null;
+    // 転送が一時的に止まって見える(ポーリング間隔とディスク書き込みのタイミングがずれる)だけで
+    // 速度0になることがあるため、その場合は直前のETAを維持し「計算中...」への逆戻りを防ぐ。
+    const etaSeconds =
+      bytesPerSec > 0
+        ? Math.max(0, Math.round(remaining / bytesPerSec))
+        : (downloadProgress?.etaSeconds ?? null);
 
     downloadProgress = {
       downloadedBytes: downloaded,


### PR DESCRIPTION
ポーリング間隔(1秒)とディスク書き込みタイミングのずれで転送速度が
一時的に0と計測されると、etaSecondsがnullに戻り「計算中...」の表示が
繰り返し出ていた。速度0の場合は直前のETAを維持するようにした。