### PR TITLE
fix(voice): tsunagi本体が実際に使うvenvセットアップにバージョン検証を反映

### DIFF
--- a/apps/server/src/lib/llm-process.ts
+++ b/apps/server/src/lib/llm-process.ts
@@ -4,6 +4,12 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { killProcessOnPort } from './process-port.js';
+import {
+  findPython,
+  isVenvUpToDate,
+  PYTHON_NOT_FOUND_MESSAGE,
+  writeVenvMarker,
+} from './python-venv.js';
 
 const MODEL = 'mlx-community/Qwen3-30B-A3B-Instruct-2507-4bit';
 
@@ -50,10 +56,6 @@ export function findLlmServerDir(): string | null {
 
 function venvPython(): string {
   return path.join(VENV_DIR, 'bin', 'python3');
-}
-
-function isVenvReady(): boolean {
-  return fs.existsSync(venvPython());
 }
 
 function isModelReady(): boolean {
@@ -177,12 +179,17 @@ async function trackModelDownload(child: ChildProcess): Promise<void> {
 
 async function runSetupAndStart(dir: string): Promise<void> {
   const hfEnv = { ...process.env, HF_HOME: HF_CACHE_DIR, HF_HUB_DISABLE_XET: '1' };
+  const requirementsFile = path.join(dir, 'requirements.txt');
 
-  if (!isVenvReady()) {
+  if (!isVenvUpToDate(VENV_DIR, requirementsFile)) {
     currentStep = 'installing_deps';
+    const pythonBin = findPython();
+    if (!pythonBin) throw new Error(PYTHON_NOT_FOUND_MESSAGE);
     fs.mkdirSync(TSUNAGI_LLM_DIR, { recursive: true });
-    await runStep('python3', ['-m', 'venv', VENV_DIR], dir);
+    fs.rmSync(VENV_DIR, { recursive: true, force: true });
+    await runStep(pythonBin, ['-m', 'venv', VENV_DIR], dir);
     await runStep(venvPython(), ['-m', 'pip', 'install', '-r', 'requirements.txt'], dir);
+    writeVenvMarker(VENV_DIR, requirementsFile);
   }
 
   if (!isModelReady()) {

--- a/apps/server/src/lib/python-venv.ts
+++ b/apps/server/src/lib/python-venv.ts
@@ -1,0 +1,72 @@
+import { execFileSync } from 'node:child_process';
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+// mlx/mlx-lm/mlx-whisper の固定バージョンが requires-python >=3.10 のため、venv作成に
+// 使う python3 自体も 3.10 以上でなければ pip install がそもそも失敗する。`python3` という
+// 名前が PATH 上のどのバージョンを指すかは環境依存(古い macOS 付属 Python 等)なため、
+// 候補を新しい順に探して最初に見つかった 3.10 以上を使う。
+const MIN_PYTHON_VERSION = '3.10';
+const PYTHON_CANDIDATES = [
+  'python3.14',
+  'python3.13',
+  'python3.12',
+  'python3.11',
+  'python3.10',
+  'python3',
+];
+
+function pythonVersion(bin: string): string | null {
+  try {
+    return execFileSync(bin, ['-c', 'import sys; print("%d.%d" % sys.version_info[:2])'], {
+      encoding: 'utf8',
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function versionAtLeast(version: string, min: string): boolean {
+  const [vMajor, vMinor] = version.split('.').map(Number);
+  const [mMajor, mMinor] = min.split('.').map(Number);
+  return vMajor !== mMajor ? vMajor > mMajor : vMinor >= mMinor;
+}
+
+export function findPython(): string | null {
+  for (const cand of PYTHON_CANDIDATES) {
+    const version = pythonVersion(cand);
+    if (version && versionAtLeast(version, MIN_PYTHON_VERSION)) return cand;
+  }
+  return null;
+}
+
+export const PYTHON_NOT_FOUND_MESSAGE = `Python ${MIN_PYTHON_VERSION}以上が見つかりません。'brew install python@3.12' 等でインストールしてください。`;
+
+function venvMarkerPath(venvDir: string): string {
+  return path.join(venvDir, '.requirements.sha256');
+}
+
+function requirementsHash(requirementsFile: string): string {
+  return crypto.createHash('sha256').update(fs.readFileSync(requirementsFile)).digest('hex');
+}
+
+// venvが「存在するだけ」でなく、実際に使えるかを検証する。
+// - venv作成に使われた python が 3.10 未満だと mlx 系のインストールに失敗するバージョンのまま放置される
+// - requirements.txt のバージョン指定を後から変更しても、既存venvには反映されない
+// のいずれかが起きていないかを、venv自身のpythonバージョンと記録済みハッシュから判定する。
+export function isVenvUpToDate(venvDir: string, requirementsFile: string): boolean {
+  const venvPython = path.join(venvDir, 'bin', 'python3');
+  if (!fs.existsSync(venvPython)) return false;
+
+  const version = pythonVersion(venvPython);
+  if (!version || !versionAtLeast(version, MIN_PYTHON_VERSION)) return false;
+
+  const marker = venvMarkerPath(venvDir);
+  if (!fs.existsSync(marker)) return false;
+  return fs.readFileSync(marker, 'utf8').trim() === requirementsHash(requirementsFile);
+}
+
+export function writeVenvMarker(venvDir: string, requirementsFile: string): void {
+  fs.writeFileSync(venvMarkerPath(venvDir), requirementsHash(requirementsFile));
+}

--- a/apps/server/src/lib/whisper-process.ts
+++ b/apps/server/src/lib/whisper-process.ts
@@ -4,6 +4,12 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { killProcessOnPort } from './process-port.js';
+import {
+  findPython,
+  isVenvUpToDate,
+  PYTHON_NOT_FOUND_MESSAGE,
+  writeVenvMarker,
+} from './python-venv.js';
 
 const WHISPER_SERVER_URL = process.env.TSUNAGI_WHISPER_SERVER_URL || 'http://127.0.0.1:8765';
 // run.shが待受けるポート固定値(host.docker.internal経由URLと違い、停止処理は
@@ -42,10 +48,6 @@ export function findWhisperServerDir(): string | null {
 
 function venvPython(): string {
   return path.join(VENV_DIR, 'bin', 'python3');
-}
-
-function isVenvReady(): boolean {
-  return fs.existsSync(venvPython());
 }
 
 function isModelReady(): boolean {
@@ -169,12 +171,17 @@ async function trackModelDownload(child: ChildProcess): Promise<void> {
 
 async function runSetupAndStart(dir: string): Promise<void> {
   const hfEnv = { ...process.env, HF_HOME: HF_CACHE_DIR, HF_HUB_DISABLE_XET: '1' };
+  const requirementsFile = path.join(dir, 'requirements.txt');
 
-  if (!isVenvReady()) {
+  if (!isVenvUpToDate(VENV_DIR, requirementsFile)) {
     currentStep = 'installing_deps';
+    const pythonBin = findPython();
+    if (!pythonBin) throw new Error(PYTHON_NOT_FOUND_MESSAGE);
     fs.mkdirSync(TSUNAGI_WHISPER_DIR, { recursive: true });
-    await runStep('python3', ['-m', 'venv', VENV_DIR], dir);
+    fs.rmSync(VENV_DIR, { recursive: true, force: true });
+    await runStep(pythonBin, ['-m', 'venv', VENV_DIR], dir);
     await runStep(venvPython(), ['-m', 'pip', 'install', '-r', 'requirements.txt'], dir);
+    writeVenvMarker(VENV_DIR, requirementsFile);
   }
 
   if (!isModelReady()) {


### PR DESCRIPTION
apps/server/src/lib/llm-process.ts・whisper-process.tsは、venv作成/pip installを run.shとは別にNode側で独自に再実装しており、実際のサーバー起動はこちらの経路を
通る(run.shはディレクトリ検出のマーカーとしてのみ使われる)。このNode側の実装は
venvディレクトリの有無しか見ておらず、python3のバージョン検証もrequirements.txt 変更時の再インストールも行っていなかったため、run.shに入れた修正(mlx-lm/mlx-whisper のバージョン固定、Python 3.10以上の検出、既存venvの自動更新)が実際の起動時には
反映されていなかった。

apps/server/src/lib/python-venv.tsに検証ロジックを切り出し、llm-process.ts/ whisper-process.tsの両方から使うよう変更。既存venvがあっても、venv作成に使われた pythonが3.10未満、またはrequirements.txtの内容が変わっている場合は作り直す。